### PR TITLE
Statically link to libstdc++.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -94,17 +94,22 @@ fn main() {
         .write_to_file(out_path.join("v8_c_bindings.rs"))
         .expect("failed to write bindings to file");
 
-
     match std::env::consts::OS {
         "linux" => {
             /* On linux we will statically link to libstdc++ to be able to run on systems that do not have libstdc++ installed. */
-            println!("cargo:rustc-flags=-L{} -lv8 -lv8_monolith -ldl -lc", output_dir);
+            println!(
+                "cargo:rustc-flags=-L{} -lv8 -lv8_monolith -ldl -lc",
+                output_dir
+            );
             println!("cargo:rustc-cdylib-link-arg=-Wl,-Bstatic");
             println!("cargo:rustc-cdylib-link-arg=-lstdc++");
             println!("cargo:rustc-cdylib-link-arg=-Wl,-Bdynamic");
         }
         "macos" => {
-            println!("cargo:rustc-flags=-L{} -lv8 -lv8_monolith -lc++ -ldl -lc", output_dir);
+            println!(
+                "cargo:rustc-flags=-L{} -lv8 -lv8_monolith -lc++ -ldl -lc",
+                output_dir
+            );
         }
         _ => panic!("Os '{}' are not supported", std::env::consts::OS),
     }


### PR DESCRIPTION
On linux we will statically link to libstdc++ to be able to run on systems that do not have libstdc++ installed.