### PR TITLE
Expose git commit hash used when building.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [build-dependencies]
 bindgen = "0.59.2"
+vergen = { version = "8", features = ["git", "gitcl"] }
 
 [dev-dependencies]
 v8_rs_derive = { path = "./v8-rs-derive/"}

--- a/build.rs
+++ b/build.rs
@@ -4,8 +4,6 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-extern crate bindgen;
-
 use std::env;
 use std::path::Path;
 use std::path::PathBuf;
@@ -113,4 +111,9 @@ fn main() {
         }
         _ => panic!("Os '{}' are not supported", std::env::consts::OS),
     }
+
+    vergen::EmitBuilder::builder()
+        .all_git()
+        .emit()
+        .expect("vergen failed.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,13 @@
 pub mod v8;
 mod v8_c_raw;
 
+/// The [`vergen`]'s git hash (long) - the full SHA hash of the commit
+/// the crate was build from.
+pub const GIT_SHA: &str = env!("VERGEN_GIT_SHA");
+/// The [`vergen`]'s git semantic version based on the last checkout tag,
+/// the number of commits ahead of the tag and a hash.
+pub const GIT_SEMVER: &str = env!("VERGEN_GIT_DESCRIBE");
+
 /// A user-available data index. The users of the crate may use this
 /// index to store their data in V8.
 #[repr(transparent)]


### PR DESCRIPTION
Exposes the git commit sha hash (full length) used when building the crate. It is obtained via the vergen crate.