### PR TITLE
Added the ability to update the V8 headers files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 [build-dependencies]
 bindgen = "0.59.2"
 vergen = { version = "8", features = ["git", "gitcl"] }
+lazy_static = "1"
 
 [dev-dependencies]
 v8_rs_derive = { path = "./v8-rs-derive/"}

--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ let res = script.run(&ctx_scope).unwrap();
 let res_utf8 = res.to_utf8(&isolate).unwrap();
 assert_eq!(res_utf8.as_str(), "2");
 ```
+
+## Build Options
+
+Usually, just adding the crate as a dependency in your project will be enough. That said it is possible to change the following build option using evironment variables.
+
+* V8_VERSION - will change the default V8 version to use.
+* V8_UPDATE_HEADERS - will update the V8 headers according to the set version, allow to also set the following options:
+  * V8_HEADERS_PATH - control where to download the headers zip file, default `v8_c_api/libv8.include.zip`.
+  * V8_FORCE_DOWNLOAD_V8_HEADERS - download the V8 headers zip file even if it is already exists.
+  * V8_HEADERS_URL - url from where to download the V8 headers zip file.
+* V8_MONOLITH_PATH - control where to download the V8 monolith, default `v8_c_api/libv8_monolith.a`
+* V8_FORCE_DOWNLOAD_V8_MONOLITH - download the V8 monolith even if it is already exists.
+* V8_MONOLITH_URL - url from where to download the V8 monolith file.

--- a/build.rs
+++ b/build.rs
@@ -9,36 +9,63 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
+const V8_VERSION: &str = "10.8.168.21";
+
+fn run_cmd(cmd: &str, args: &[&str]) {
+    let failure_message = format!("Failed running command: {} {}", cmd, args.join(" "));
+    if !Command::new(cmd)
+        .args(args)
+        .status()
+        .expect(&failure_message)
+        .success()
+    {
+        panic!("{}", failure_message);
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=v8_c_api/src/v8_c_api.h");
     println!("cargo:rerun-if-changed=v8_c_api/src/v8_c_api.cpp");
 
-    if !Command::new("make")
-        .args(["-C", "v8_c_api/"])
-        .status()
-        .expect("failed to compile v8_c_api")
-        .success()
-    {
-        panic!("failed to compile v8_c_api");
+    let version = env::var("V8_VERSION").unwrap_or(V8_VERSION.into());
+
+    if let Ok(v8_update_header) = env::var("V8_UPDATE_HEADERS") {
+        if v8_update_header == "yes" {
+            // download and update headers
+            let v8_headers_path =
+                env::var("V8_HEADERS_PATH").unwrap_or("v8_c_api/libv8.include.zip".into());
+            let force_download_v8_headers = env::var("V8_FORCE_DOWNLOAD_V8_HEADERS")
+                .map(|v| v == "yes")
+                .unwrap_or(false);
+            if force_download_v8_headers {
+                run_cmd("rm", &["-rf", &v8_headers_path]);
+            }
+            if !Path::new(&v8_headers_path).exists() {
+                let v8_headers_url = env::var("V8_HEADERS_URL").unwrap_or(format!(
+                    "http://redismodules.s3.amazonaws.com/redisgears/dependencies/libv8.{}.include.zip", version));
+                run_cmd("wget", &["-O", &v8_headers_path, &v8_headers_url]);
+            }
+
+            run_cmd("rm", &["-rf", "v8_c_api/src/v8include/"]);
+            run_cmd(
+                "unzip",
+                &[&v8_headers_path, "-d", "v8_c_api/src/v8include/"],
+            );
+        }
     }
+
+    run_cmd("make", &["-C", "v8_c_api/"]);
 
     let output_dir = env::var("OUT_DIR").expect("Can not find out directory");
 
-    if !Command::new("cp")
-        .args(["v8_c_api/src/libv8.a", &output_dir])
-        .status()
-        .expect("failed copy libv8.a to output directory")
-        .success()
-    {
-        panic!("failed copy libv8.a to output directory");
-    }
+    run_cmd("cp", &["v8_c_api/src/libv8.a", &output_dir]);
 
-    let v8_monolith_path = match env::var("V8_MONOLITH_PATH") {
-        Ok(path) => path,
-        Err(_) => "v8_c_api/libv8_monolith.a".to_string(),
-    };
+    let force_download_v8_monolith = env::var("V8_FORCE_DOWNLOAD_V8_MONOLITH")
+        .map(|v| v == "yes")
+        .unwrap_or(false);
 
-    let version = "10.8.168.21";
+    let v8_monolith_path =
+        env::var("V8_MONOLITH_PATH").unwrap_or("v8_c_api/libv8_monolith.a".into());
 
     let arch = match std::env::consts::ARCH {
         "x86_64" => "x64",
@@ -52,31 +79,21 @@ fn main() {
         _ => panic!("Os '{}' are not supported", std::env::consts::OS),
     };
 
-    let v8_monolith_url = match env::var("V8_MONOLITH_URL") {
-        Ok(path) => path,
-        Err(_) => format!("http://redismodules.s3.amazonaws.com/redisgears/dependencies/libv8_monolith.{}.{}.{}.a", version, arch, os),
-    };
+    let v8_monolith_url = env::var("V8_MONOLITH_URL").unwrap_or(format!(
+        "http://redismodules.s3.amazonaws.com/redisgears/dependencies/libv8_monolith.{}.{}.{}.a",
+        version, arch, os
+    ));
+
+    if force_download_v8_monolith {
+        run_cmd("rm", &["-rf", &v8_monolith_path]);
+    }
 
     if !Path::new(&v8_monolith_path).exists() {
         // download libv8_monolith.a
-        if !Command::new("wget")
-            .args(["-O", &v8_monolith_path, &v8_monolith_url])
-            .status()
-            .expect("failed downloading libv8_monolith.a")
-            .success()
-        {
-            panic!("failed downloading libv8_monolith.a");
-        }
+        run_cmd("wget", &["-O", &v8_monolith_path, &v8_monolith_url]);
     }
 
-    if !Command::new("cp")
-        .args([&v8_monolith_path, &output_dir])
-        .status()
-        .expect("failed copy libv8_monolith.a to output directory")
-        .success()
-    {
-        panic!("failed copy libv8_monolith.a to output directory");
-    }
+    run_cmd("cp", &[&v8_monolith_path, &output_dir]);
 
     let build = bindgen::Builder::default();
 


### PR DESCRIPTION
The PR adds the ability to update the V8 headers file and control different build options using evironment variable. The evironment variable are:

* V8_VERSION - will change the default V8 version to use.
* V8_UPDATE_HEADERS - will update the V8 headers according to the set version, allow to also set the following options:
  * V8_HEADERS_PATH - control where to download the headers zip file, default `v8_c_api/libv8.include.zip`.
  * V8_FORCE_DOWNLOAD_V8_HEADERS - download the V8 headers zip file even if it is already exists.
  * V8_HEADERS_URL - url from where to download the V8 headers zip file.
* V8_MONOLITH_PATH - control where to download the V8 monolith, default `v8_c_api/libv8_monolith.a`
* V8_FORCE_DOWNLOAD_V8_MONOLITH - download the V8 monolith even if it is already exists.
* V8_MONOLITH_URL - url from where to download the V8 monolith file.