### PR TITLE
Make build.rs code more robust by recreating the include directory if it is missing.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,7 @@ fn main() {
         }
 
         run_cmd("rm", &["-rf", *V8_HEADERS_DIRECTORY]);
+        run_cmd("mkdir", &["-p", *V8_HEADERS_DIRECTORY]);
         run_cmd("unzip", &[&V8_HEADERS_PATH, "-d", *V8_HEADERS_DIRECTORY]);
     }
 


### PR DESCRIPTION
This will solve issues where previous command (`rm`) deleted the directory. and the unzip will not recreate it.