### PR TITLE
Externd set API with as_array.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,29 @@ mod json_path_tests {
         initialize();
         let isolate = isolate::V8Isolate::new();
         let isolate_scope = isolate.enter();
+        let code_str = isolate_scope.new_string("new Set([1, 2, 3, 4]);");
+        let ctx = isolate_scope.new_context(None);
+        let ctx_scope = ctx.enter(&isolate_scope);
+        let script = ctx_scope.compile(&code_str).unwrap();
+        let res = script.run(&ctx_scope).unwrap();
+
+        assert!(res.is_set());
+        let s = res.as_set();
+        let arr = s.as_array();
+        assert_eq!(arr.len(), 4);
+        assert_eq!(
+            arr.iter(&ctx_scope)
+                .map(|v| v.get_long())
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4],
+        );
+    }
+
+    #[test]
+    fn test_set_api() {
+        initialize();
+        let isolate = isolate::V8Isolate::new();
+        let isolate_scope = isolate.enter();
         let code_str = isolate_scope.new_string("1+1");
         let ctx = isolate_scope.new_context(None);
         let ctx_scope = ctx.enter(&isolate_scope);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ impl From<UserIndex> for RawIndex {
 #[cfg(test)]
 mod json_path_tests {
     use crate as v8_rs;
+    use crate::v8::v8_array::V8LocalArray;
     use crate::v8::{
         isolate, isolate_scope, v8_array, v8_array_buffer, v8_context_scope, v8_init,
         v8_native_function_template, v8_object, v8_set, v8_utf8,
@@ -249,7 +250,7 @@ mod json_path_tests {
     }
 
     #[test]
-    fn test_simple_code_run() {
+    fn test_set_api() {
         initialize();
         let isolate = isolate::V8Isolate::new();
         let isolate_scope = isolate.enter();
@@ -260,8 +261,7 @@ mod json_path_tests {
         let res = script.run(&ctx_scope).unwrap();
 
         assert!(res.is_set());
-        let s = res.as_set();
-        let arr = s.as_array();
+        let arr: V8LocalArray = res.as_set().into();
         assert_eq!(arr.len(), 4);
         assert_eq!(
             arr.iter(&ctx_scope)
@@ -272,7 +272,7 @@ mod json_path_tests {
     }
 
     #[test]
-    fn test_set_api() {
+    fn test_simple_code_run() {
         initialize();
         let isolate = isolate::V8Isolate::new();
         let isolate_scope = isolate.enter();

--- a/src/v8/v8_array.rs
+++ b/src/v8/v8_array.rs
@@ -12,6 +12,8 @@ use crate::v8::isolate_scope::V8IsolateScope;
 use crate::v8::v8_context_scope::V8ContextScope;
 use crate::v8::v8_value::V8LocalValue;
 
+use super::v8_set::V8LocalSet;
+
 /// JS object
 pub struct V8LocalArray<'isolate_scope, 'isolate> {
     pub(crate) inner_array: *mut v8_local_array,
@@ -112,5 +114,13 @@ impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>>
         }
 
         Ok(val.as_array())
+    }
+}
+
+impl<'isolate_scope, 'isolate> From<V8LocalSet<'isolate_scope, 'isolate>>
+    for V8LocalArray<'isolate_scope, 'isolate>
+{
+    fn from(val: V8LocalSet<'isolate_scope, 'isolate>) -> Self {
+        val.as_array()
     }
 }

--- a/src/v8/v8_array.rs
+++ b/src/v8/v8_array.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::v8_c_raw::bindings::{
-    v8_ArrayGet, v8_ArrayLen, v8_ArrayToValue, v8_FreeArray, v8_local_array,
+    v8_ArrayGet, v8_ArrayLen, v8_ArrayToValue, v8_FreeArray, v8_SetAsArray, v8_local_array,
 };
 
 use crate::v8::isolate_scope::V8IsolateScope;
@@ -121,6 +121,18 @@ impl<'isolate_scope, 'isolate> From<V8LocalSet<'isolate_scope, 'isolate>>
     for V8LocalArray<'isolate_scope, 'isolate>
 {
     fn from(val: V8LocalSet<'isolate_scope, 'isolate>) -> Self {
-        val.as_array()
+        val.into()
+    }
+}
+
+impl<'isolate_scope, 'isolate> From<&V8LocalSet<'isolate_scope, 'isolate>>
+    for V8LocalArray<'isolate_scope, 'isolate>
+{
+    fn from(val: &V8LocalSet<'isolate_scope, 'isolate>) -> Self {
+        let inner_array = unsafe { v8_SetAsArray(val.inner_set) };
+        V8LocalArray {
+            inner_array,
+            isolate_scope: val.isolate_scope,
+        }
     }
 }

--- a/src/v8/v8_array.rs
+++ b/src/v8/v8_array.rs
@@ -121,7 +121,7 @@ impl<'isolate_scope, 'isolate> From<V8LocalSet<'isolate_scope, 'isolate>>
     for V8LocalArray<'isolate_scope, 'isolate>
 {
     fn from(val: V8LocalSet<'isolate_scope, 'isolate>) -> Self {
-        val.into()
+        (&val).into()
     }
 }
 

--- a/src/v8/v8_set.rs
+++ b/src/v8/v8_set.rs
@@ -4,15 +4,11 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::v8_c_raw::bindings::{
-    v8_FreeSet, v8_SetAdd, v8_SetAsArray, v8_SetToValue, v8_local_set,
-};
+use crate::v8_c_raw::bindings::{v8_FreeSet, v8_SetAdd, v8_SetToValue, v8_local_set};
 
 use crate::v8::isolate_scope::V8IsolateScope;
 use crate::v8::v8_context_scope::V8ContextScope;
 use crate::v8::v8_value::V8LocalValue;
-
-use super::v8_array::V8LocalArray;
 
 /// JS object
 pub struct V8LocalSet<'isolate_scope, 'isolate> {
@@ -33,14 +29,6 @@ impl<'isolate_scope, 'isolate> V8LocalSet<'isolate_scope, 'isolate> {
 
     pub fn add(&self, ctx_scope: &V8ContextScope, val: &V8LocalValue) {
         unsafe { v8_SetAdd(ctx_scope.inner_ctx_ref, self.inner_set, val.inner_val) };
-    }
-
-    pub fn as_array(&self) -> V8LocalArray<'isolate_scope, 'isolate> {
-        let inner_array = unsafe { v8_SetAsArray(self.inner_set) };
-        V8LocalArray {
-            inner_array,
-            isolate_scope: self.isolate_scope,
-        }
     }
 }
 

--- a/src/v8/v8_set.rs
+++ b/src/v8/v8_set.rs
@@ -35,7 +35,7 @@ impl<'isolate_scope, 'isolate> V8LocalSet<'isolate_scope, 'isolate> {
         unsafe { v8_SetAdd(ctx_scope.inner_ctx_ref, self.inner_set, val.inner_val) };
     }
 
-    pub fn as_array(&self) -> V8LocalArray {
+    pub fn as_array(&self) -> V8LocalArray<'isolate_scope, 'isolate> {
         let inner_array = unsafe { v8_SetAsArray(self.inner_set) };
         V8LocalArray {
             inner_array,

--- a/src/v8/v8_set.rs
+++ b/src/v8/v8_set.rs
@@ -4,11 +4,15 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::v8_c_raw::bindings::{v8_FreeSet, v8_SetAdd, v8_SetToValue, v8_local_set};
+use crate::v8_c_raw::bindings::{
+    v8_FreeSet, v8_SetAdd, v8_SetAsArray, v8_SetToValue, v8_local_set,
+};
 
 use crate::v8::isolate_scope::V8IsolateScope;
 use crate::v8::v8_context_scope::V8ContextScope;
 use crate::v8::v8_value::V8LocalValue;
+
+use super::v8_array::V8LocalArray;
 
 /// JS object
 pub struct V8LocalSet<'isolate_scope, 'isolate> {
@@ -29,6 +33,14 @@ impl<'isolate_scope, 'isolate> V8LocalSet<'isolate_scope, 'isolate> {
 
     pub fn add(&self, ctx_scope: &V8ContextScope, val: &V8LocalValue) {
         unsafe { v8_SetAdd(ctx_scope.inner_ctx_ref, self.inner_set, val.inner_val) };
+    }
+
+    pub fn as_array(&self) -> V8LocalArray {
+        let inner_array = unsafe { v8_SetAsArray(self.inner_set) };
+        V8LocalArray {
+            inner_array,
+            isolate_scope: self.isolate_scope,
+        }
     }
 }
 

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1220,6 +1220,14 @@ v8_local_set* v8_NewSet(v8_isolate *i) {
 /* Add a value to the set */
 void v8_SetAdd(v8_context_ref *ctx_ref, v8_local_set *set, v8_local_value *val) {
 	v8::MaybeLocal<v8::Set> res = set->set->Add(ctx_ref->context, val->val);
+
+}
+
+v8_local_array* v8_SetAsArray(v8_local_set *set) {
+	v8::Local<v8::Array> arr = set->set->AsArray();
+	v8_local_array *res = (v8_local_array*) V8_ALLOC(sizeof(*res));
+	res = new (res) v8_local_array(arr);
+	return res;
 }
 
 /* Convert the given JS set into JS generic value */

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -451,6 +451,9 @@ v8_local_set* v8_NewSet(v8_isolate *i);
 /* Add a value to the set */
 void v8_SetAdd(v8_context_ref *ctx_ref, v8_local_set *set, v8_local_value *val);
 
+/* Turn the set into an array for iterations. */
+v8_local_array* v8_SetAsArray(v8_local_set *set);
+
 /* Convert the given JS set into JS generic value */
 v8_local_value* v8_SetToValue(v8_local_set *set);
 


### PR DESCRIPTION
The new API allows to get the set as an array and user all array feature on it (for example, iterate on all the elements inside the set).

The PR also adds test to verify the new API.