### PR TITLE
The PR adds new APIs on the V8LocalObject.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,37 @@ mod json_path_tests {
     }
 
     #[test]
+    fn test_delete_object_property() {
+        initialize();
+        let isolate = isolate::V8Isolate::new();
+        let isolate_scope = isolate.enter();
+        let ctx = isolate_scope.new_context(None);
+        let ctx_scope = ctx.enter(&isolate_scope);
+
+        let property_name = isolate_scope.new_string("foo").to_value();
+        let object = isolate_scope.new_object();
+        object.set(&ctx_scope, &property_name, &isolate_scope.new_long(1));
+
+        assert_eq!(
+            &object
+                .get_own_property_names(&ctx_scope)
+                .iter(&ctx_scope)
+                .map(|v| v.to_utf8().unwrap().as_str().to_owned())
+                .collect::<Vec<String>>(),
+            &["foo".to_owned()]
+        );
+
+        assert!(object.delete(&ctx_scope, &property_name));
+
+        assert!(object
+            .get_own_property_names(&ctx_scope)
+            .iter(&ctx_scope)
+            .map(|v| v.to_utf8().unwrap().as_str().to_owned())
+            .collect::<Vec<String>>()
+            .is_empty());
+    }
+
+    #[test]
     fn test_simple_code_run() {
         initialize();
         let isolate = isolate::V8Isolate::new();

--- a/src/v8/isolate.rs
+++ b/src/v8/isolate.rs
@@ -7,9 +7,10 @@
 
 use crate::v8_c_raw::bindings::{
     v8_CancelTerminateExecution, v8_FreeIsolate, v8_IdleNotificationDeadline, v8_IsolateGetCurrent,
-    v8_IsolateNotifyMemoryPressure, v8_IsolateSetFatalErrorHandler, v8_IsolateSetNearOOMHandler,
-    v8_IsolateSetOOMErrorHandler, v8_IsolateTotalHeapSize, v8_IsolateUsedHeapSize, v8_NewIsolate,
-    v8_RequestInterrupt, v8_TerminateCurrExecution, v8_isolate,
+    v8_IsolateHeapSizeLimit, v8_IsolateNotifyMemoryPressure, v8_IsolateSetFatalErrorHandler,
+    v8_IsolateSetNearOOMHandler, v8_IsolateSetOOMErrorHandler, v8_IsolateTotalHeapSize,
+    v8_IsolateUsedHeapSize, v8_NewIsolate, v8_RequestInterrupt, v8_TerminateCurrExecution,
+    v8_isolate,
 };
 
 use std::os::raw::c_void;
@@ -169,6 +170,12 @@ impl V8Isolate {
     /// garbage-collected.
     pub fn total_heap_size(&self) -> usize {
         unsafe { v8_IsolateTotalHeapSize(self.inner_isolate) }
+    }
+
+    /// Returns the statistics about the heap memory usage.
+    /// The number returned is current heap size limit.
+    pub fn heap_size_limit(&self) -> usize {
+        unsafe { v8_IsolateHeapSizeLimit(self.inner_isolate) }
     }
 
     /// Sets the notification that the system is running low on memory.

--- a/src/v8/v8_object.rs
+++ b/src/v8/v8_object.rs
@@ -150,7 +150,6 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
 
     /// Delete a property from the object by the property name.
     /// Return `true` if the delete was done successfully.
-    #[must_use]
     pub fn delete(&self, ctx_scope: &V8ContextScope, key: &V8LocalValue) -> bool {
         let res =
             unsafe { v8_DeletePropery(ctx_scope.inner_ctx_ref, self.inner_obj, key.inner_val) };

--- a/src/v8/v8_object.rs
+++ b/src/v8/v8_object.rs
@@ -5,9 +5,9 @@
  */
 
 use crate::v8_c_raw::bindings::{
-    v8_FreeObject, v8_GetInternalFieldCount, v8_ObjectFreeze, v8_ObjectGet,
+    v8_DeletePropery, v8_FreeObject, v8_GetInternalFieldCount, v8_ObjectFreeze, v8_ObjectGet,
     v8_ObjectGetInternalField, v8_ObjectSet, v8_ObjectSetInternalField, v8_ObjectToValue,
-    v8_ValueGetPropertyNames, v8_local_object,
+    v8_ValueGetOwnPropertyNames, v8_ValueGetPropertyNames, v8_local_object,
 };
 
 use crate::v8::isolate_scope::V8IsolateScope;
@@ -120,7 +120,7 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
         unsafe { v8_ObjectFreeze(ctx_scope.inner_ctx_ref, self.inner_obj) };
     }
 
-    /// Convert the object into a generic JS value
+    /// Return an array contains the enumerable properties names of the given object
     #[must_use]
     pub fn get_property_names(
         &self,
@@ -132,6 +132,29 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
             inner_array,
             isolate_scope: self.isolate_scope,
         }
+    }
+
+    /// Return an array contains all the properties names of the given object
+    #[must_use]
+    pub fn get_own_property_names(
+        &self,
+        ctx_scope: &V8ContextScope,
+    ) -> V8LocalArray<'isolate_scope, 'isolate> {
+        let inner_array =
+            unsafe { v8_ValueGetOwnPropertyNames(ctx_scope.inner_ctx_ref, self.inner_obj) };
+        V8LocalArray {
+            inner_array,
+            isolate_scope: self.isolate_scope,
+        }
+    }
+
+    /// Delete a property from the object by the property name.
+    /// Return `true` if the delete was done successfully.
+    #[must_use]
+    pub fn delete(&self, ctx_scope: &V8ContextScope, key: &V8LocalValue) -> bool {
+        let res =
+            unsafe { v8_DeletePropery(ctx_scope.inner_ctx_ref, self.inner_obj, key.inner_val) };
+        res != 0
     }
 }
 

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -342,6 +342,13 @@ size_t v8_IsolateTotalHeapSize(v8_isolate* i) {
 	return heap.total_heap_size();
 }
 
+size_t v8_IsolateHeapSizeLimit(v8_isolate* i) {
+	v8::Isolate *isolate = (v8::Isolate*)i;
+	v8::HeapStatistics heap;
+	isolate->GetHeapStatistics(&heap);
+	return heap.heap_size_limit();
+}
+
 void v8_IsolateNotifyMemoryPressure(v8_isolate* i) {
 	v8::Isolate *isolate = (v8::Isolate*)i;
 	isolate->MemoryPressureNotification(v8::MemoryPressureLevel::kCritical);

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1070,6 +1070,25 @@ v8_local_array* v8_ValueGetPropertyNames(v8_context_ref *ctx_ref, v8_local_objec
 	return res;
 }
 
+v8_local_array* v8_ValueGetOwnPropertyNames(v8_context_ref *ctx_ref, v8_local_object *obj) {
+	v8::MaybeLocal<v8::Array> maybe_res = obj->obj->GetOwnPropertyNames(ctx_ref->context, v8::PropertyFilter::ALL_PROPERTIES);
+	if (maybe_res.IsEmpty()) {
+		return NULL;
+	}
+	v8::Local<v8::Array> arr = maybe_res.ToLocalChecked();
+	v8_local_array *res = (v8_local_array*) V8_ALLOC(sizeof(*res));
+	res = new (res) v8_local_array(arr);
+	return res;
+}
+
+int v8_DeletePropery(v8_context_ref *ctx_ref, v8_local_object *obj, v8_local_value *key) {
+	v8::Maybe<bool> res = obj->obj->Delete(ctx_ref->context, key->val);
+	if (res.IsNothing()) {
+		return false;
+	}
+	return res.ToChecked();
+}
+
 int v8_ValueIsArray(v8_local_value *val) {
 	return val->val->IsArray();
 }

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -140,6 +140,9 @@ size_t v8_IsolateUsedHeapSize(v8_isolate* i);
 /* Return the currently total heap size */
 size_t v8_IsolateTotalHeapSize(v8_isolate* i);
 
+/* Return the current heap size limit */
+size_t v8_IsolateHeapSizeLimit(v8_isolate* i);
+
 void v8_IsolateNotifyMemoryPressure(v8_isolate* i);
 
 /* Return the currently used isolate or NULL if not isolate is in used */

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -390,8 +390,14 @@ int v8_ValueIsObject(v8_local_value *val);
 
 int v8_ValueIsExternalData(v8_local_value *val);
 
-/* Return an array contains the propery names of the given object */
+/* Return an array contains the enumerable properties names of the given object */
 v8_local_array* v8_ValueGetPropertyNames(v8_context_ref *ctx_ref, v8_local_object *obj);
+
+/* Return an array contains the all properties names of the given object */
+v8_local_array* v8_ValueGetOwnPropertyNames(v8_context_ref *ctx_ref, v8_local_object *obj);
+
+/* Deleted the given propery from the object */
+int v8_DeletePropery(v8_context_ref *ctx_ref, v8_local_object *obj, v8_local_value *key);
 
 /* Return 1 if the given JS value is an array and 0 otherwise */
 int v8_ValueIsArray(v8_local_value *val);


### PR DESCRIPTION
The PR adds the following new API:

1. `get_own_property_names` - return all properties of an object including none enumerables.
2. `delete` - deletes a property by property name.
3. `heap_size_limit` - return the current heap size limit value