### PR TITLE
Introduce `NativeFunctionArgument` for auto JS object argument parsing.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,6 +954,30 @@ mod json_path_tests {
     }
 
     #[test]
+    fn test_wrong_type_on_object_argument_macro() {
+        let err = define_function_and_call(
+            "test({i: 1, s: 'foo', b: 'false', inner: { i: 10 }})",
+            "test",
+            new_native_function!(|_isolate, _ctx_scope, args: Args| {
+                assert_eq!(
+                    args,
+                    Args {
+                        i: 1,
+                        s: "foo".to_owned(),
+                        b: false,
+                        o: None,
+                        inner: InnerArgs { i: 10 },
+                        optional_inner: None,
+                    },
+                );
+                Result::<Option<v8_value::V8LocalValue>, String>::Ok(None)
+            }),
+        )
+        .expect_err("Did not get error when suppose to.");
+        assert!(err.contains("Failed getting field b, Value is not a boolean"));
+    }
+
+    #[test]
     fn test_extra_fields_on_object_argument_macro() {
         let err = define_function_and_call(
             "test({i: 1, s: 'foo', b: false, inner: { i: 10, extra: true }})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -949,4 +949,28 @@ mod json_path_tests {
         .expect_err("Did not get error when suppose to.");
         assert!(err.contains("Failed getting field inner, Given argument must be an object"));
     }
+
+    #[test]
+    fn test_extra_fields_on_object_argument_macro() {
+        let err = define_function_and_call(
+            "test({i: 1, s: 'foo', b: false, inner: { i: 10, extra: true }})",
+            "test",
+            new_native_function!(|_isolate, _ctx_scope, args: Args| {
+                assert_eq!(
+                    args,
+                    Args {
+                        i: 1,
+                        s: "foo".to_owned(),
+                        b: false,
+                        o: None,
+                        inner: InnerArgs { i: 10 },
+                        optional_inner: None,
+                    },
+                );
+                Result::<Option<v8_value::V8LocalValue>, String>::Ok(None)
+            }),
+        )
+        .expect_err("Did not get error when suppose to.");
+        assert!(err.contains("Unknown properties given: extra"));
+    }
 }

--- a/src/v8/v8_array.rs
+++ b/src/v8/v8_array.rs
@@ -103,12 +103,12 @@ impl<'isolate_scope, 'isolate> Drop for V8LocalArray<'isolate_scope, 'isolate> {
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>>
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>>
     for V8LocalArray<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_array() {
             return Err("Value is not an array");
         }

--- a/src/v8/v8_array_buffer.rs
+++ b/src/v8/v8_array_buffer.rs
@@ -40,11 +40,11 @@ impl<'isolate_scope, 'isolate> Drop for V8LocalArrayBuffer<'isolate_scope, 'isol
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>>
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>>
     for V8LocalArrayBuffer<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_array_buffer() {
             return Err("Value is not an array buffer");
         }

--- a/src/v8/v8_native_function_template.rs
+++ b/src/v8/v8_native_function_template.rs
@@ -145,21 +145,34 @@ impl<'isolate_scope, 'isolate> V8LocalNativeFunctionArgs<'isolate_scope, 'isolat
 
     pub const fn persist(&self) {}
 
-    pub fn iter<'a>(&'a self) -> V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a> {
+    pub fn iter<'a, 'ctx_scope>(
+        &'a self,
+        ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+    ) -> V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a> {
         V8LocalNativeFunctionArgsIter {
             args: self,
             index: 0,
+            ctx_scope: ctx_scope,
         }
     }
 }
 
-pub struct V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a> {
+pub struct V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a> {
     args: &'a V8LocalNativeFunctionArgs<'isolate_scope, 'isolate>,
     index: usize,
+    ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
 }
 
-impl<'isolate_scope, 'isolate, 'a> Iterator
-    for V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a>
+    V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>
+{
+    pub fn get_ctx_scope(&self) -> &'ctx_scope V8ContextScope<'isolate_scope, 'isolate> {
+        self.ctx_scope
+    }
+}
+
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a> Iterator
+    for V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>
 {
     type Item = V8LocalValue<'isolate_scope, 'isolate>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/v8/v8_object.rs
+++ b/src/v8/v8_object.rs
@@ -53,8 +53,7 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
         self.get(ctx_scope, &key.to_value())
     }
 
-    /// Sugar for get that recieve the field name as &str
-    #[must_use]
+    /// Pop the given key out of the object and return it
     pub fn pop(
         &self,
         ctx_scope: &V8ContextScope,
@@ -65,8 +64,7 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
         res
     }
 
-    /// Sugar for get that recieve the field name as &str
-    #[must_use]
+    /// Sugar for pop that recieve the field name as &str
     pub fn pop_str_field(
         &self,
         ctx_scope: &V8ContextScope,

--- a/src/v8/v8_object.rs
+++ b/src/v8/v8_object.rs
@@ -163,12 +163,12 @@ impl<'isolate_scope, 'isolate> Drop for V8LocalObject<'isolate_scope, 'isolate> 
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>>
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>>
     for V8LocalObject<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_object() {
             return Err("Value is not an object");
         }

--- a/src/v8/v8_object.rs
+++ b/src/v8/v8_object.rs
@@ -53,6 +53,29 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
         self.get(ctx_scope, &key.to_value())
     }
 
+    /// Sugar for get that recieve the field name as &str
+    #[must_use]
+    pub fn pop(
+        &self,
+        ctx_scope: &V8ContextScope,
+        key: &V8LocalValue,
+    ) -> Option<V8LocalValue<'isolate_scope, 'isolate>> {
+        let res = self.get(ctx_scope, key);
+        self.delete(ctx_scope, key);
+        res
+    }
+
+    /// Sugar for get that recieve the field name as &str
+    #[must_use]
+    pub fn pop_str_field(
+        &self,
+        ctx_scope: &V8ContextScope,
+        key: &str,
+    ) -> Option<V8LocalValue<'isolate_scope, 'isolate>> {
+        let key = self.isolate_scope.new_string(key);
+        self.pop(ctx_scope, &key.to_value())
+    }
+
     pub fn set(&self, ctx_scope: &V8ContextScope, key: &V8LocalValue, val: &V8LocalValue) {
         unsafe {
             v8_ObjectSet(

--- a/src/v8/v8_set.rs
+++ b/src/v8/v8_set.rs
@@ -38,12 +38,12 @@ impl<'isolate_scope, 'isolate> Drop for V8LocalSet<'isolate_scope, 'isolate> {
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>>
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>>
     for V8LocalSet<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_set() {
             return Err("Value is not a set");
         }

--- a/src/v8/v8_utf8.rs
+++ b/src/v8/v8_utf8.rs
@@ -35,12 +35,12 @@ impl<'isolate_scope, 'isolate> Drop for V8LocalUtf8<'isolate_scope, 'isolate> {
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>>
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>>
     for V8LocalUtf8<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_string() && !val.is_string_object() {
             return Err("Value is not string");
         }

--- a/src/v8/v8_value.rs
+++ b/src/v8/v8_value.rs
@@ -11,7 +11,7 @@ use crate::v8_c_raw::bindings::{
     v8_ValueAsString, v8_ValueIsArray, v8_ValueIsArrayBuffer, v8_ValueIsAsyncFunction,
     v8_ValueIsBigInt, v8_ValueIsBool, v8_ValueIsExternalData, v8_ValueIsFunction, v8_ValueIsNull,
     v8_ValueIsNumber, v8_ValueIsObject, v8_ValueIsPromise, v8_ValueIsSet, v8_ValueIsString,
-    v8_ValueIsStringObject, v8_local_value, v8_persisted_value,
+    v8_ValueIsStringObject, v8_ValueIsUndefined, v8_local_value, v8_persisted_value,
 };
 
 use std::ptr;
@@ -36,10 +36,38 @@ pub struct V8LocalValue<'isolate_scope, 'isolate> {
     pub(crate) isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
 }
 
+/// This stuct is a wrapper for `V8LocalValue` that also have access
+/// to the current `V8ContextScope`.
+/// It is used by `NativeFunctionArgument` derive macro to be able
+/// to get arguments from JS object.
+pub struct V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_scope> {
+    pub(crate) val: &'value V8LocalValue<'isolate_scope, 'isolate>,
+    pub(crate) ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+}
+
 /// JS generic persisted value
 pub struct V8PersistValue {
     pub(crate) inner_val: *mut v8_persisted_value,
     forget: bool,
+}
+
+impl<'isolate_scope, 'isolate, 'value, 'ctx_scope>
+    V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_scope>
+{
+    pub fn new(
+        val: &'value V8LocalValue<'isolate_scope, 'isolate>,
+        ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+    ) -> V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_scope> {
+        V8CtxValue { val, ctx_scope }
+    }
+
+    pub fn get_ctx_scope(&self) -> &'ctx_scope V8ContextScope<'isolate_scope, 'isolate> {
+        self.ctx_scope
+    }
+
+    pub fn get_value(&self) -> &'value V8LocalValue<'isolate_scope, 'isolate> {
+        self.val
+    }
 }
 
 impl<'isolate_scope, 'isolate> V8LocalValue<'isolate_scope, 'isolate> {
@@ -116,6 +144,12 @@ impl<'isolate_scope, 'isolate> V8LocalValue<'isolate_scope, 'isolate> {
     #[must_use]
     pub fn is_null(&self) -> bool {
         (unsafe { v8_ValueIsNull(self.inner_val) } != 0)
+    }
+
+    /// Return true if the value is null and false otherwise.
+    #[must_use]
+    pub fn is_undefined(&self) -> bool {
+        (unsafe { v8_ValueIsUndefined(self.inner_val) } != 0)
     }
 
     /// Return true if the value is function and false otherwise.
@@ -323,10 +357,10 @@ impl Drop for V8PersistValue {
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> for i64 {
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>> for i64 {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_long() {
             return Err("Value is not long");
         }
@@ -335,10 +369,10 @@ impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> f
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> for f64 {
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>> for f64 {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_number() {
             return Err("Value is not number");
         }
@@ -347,10 +381,10 @@ impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> f
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> for String {
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>> for String {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_string() && !val.is_string_object() {
             return Err("Value is not string");
         }
@@ -363,10 +397,10 @@ impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> f
     }
 }
 
-impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> for bool {
+impl<'isolate_scope, 'isolate> TryFrom<&V8LocalValue<'isolate_scope, 'isolate>> for bool {
     type Error = &'static str;
 
-    fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+    fn try_from(val: &V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
         if !val.is_boolean() {
             return Err("Value is not a boolean");
         }
@@ -386,17 +420,37 @@ impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> f
 
 macro_rules! from_iter_impl {
     ( $x:ty ) => {
-        impl<'isolate_scope, 'isolate, 'a>
-            TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>> for $x
+        impl<'isolate_scope, 'isolate> TryFrom<V8LocalValue<'isolate_scope, 'isolate>> for $x {
+            type Error = &'static str;
+
+            fn try_from(val: V8LocalValue<'isolate_scope, 'isolate>) -> Result<Self, Self::Error> {
+                (&val).try_into()
+            }
+        }
+
+        impl<'isolate_scope, 'isolate, 'ctx_scope, 'a>
+            TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>>
+            for $x
         {
             type Error = &'static str;
             fn try_from(
-                val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>,
+                val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>,
             ) -> Result<Self, Self::Error> {
                 match val.next() {
                     Some(val) => val.try_into(),
                     None => Err("Wrong number of arguments given".into()),
                 }
+            }
+        }
+
+        impl<'isolate_scope, 'isolate, 'value, 'ctx_scope>
+            TryFrom<V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_scope>> for $x
+        {
+            type Error = &'static str;
+            fn try_from(
+                val: V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_scope>,
+            ) -> Result<Self, Self::Error> {
+                val.val.try_into()
             }
         }
     };
@@ -412,26 +466,27 @@ from_iter_impl!(V8LocalObject<'isolate_scope, 'isolate>);
 from_iter_impl!(V8LocalSet<'isolate_scope, 'isolate>);
 from_iter_impl!(V8LocalUtf8<'isolate_scope, 'isolate>);
 
-impl<'isolate_scope, 'isolate, 'a>
-    TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>>
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a>
+    TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>>
     for V8LocalValue<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
     fn try_from(
-        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>,
+        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>,
     ) -> Result<Self, Self::Error> {
         val.next().ok_or("Wrong number of arguments given")
     }
 }
 
-impl<'isolate_scope, 'isolate, 'a, T>
-    OptionalTryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>> for T
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a, T>
+    OptionalTryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>>
+    for T
 where
     T: TryFrom<V8LocalValue<'isolate_scope, 'isolate>, Error = &'static str>,
 {
     type Error = &'static str;
     fn optional_try_from(
-        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>,
+        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>,
     ) -> Result<Option<Self>, Self::Error> {
         let val = match val.next() {
             Some(v) => v,
@@ -441,26 +496,26 @@ where
     }
 }
 
-impl<'isolate_scope, 'isolate, 'a>
-    OptionalTryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>>
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a>
+    OptionalTryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>>
     for V8LocalValue<'isolate_scope, 'isolate>
 {
     type Error = &'static str;
     fn optional_try_from(
-        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>,
+        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>,
     ) -> Result<Option<Self>, Self::Error> {
         Ok(val.next())
     }
 }
 
-impl<'isolate_scope, 'isolate, 'a, T>
-    TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>> for Vec<T>
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a, T>
+    TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>> for Vec<T>
 where
     T: TryFrom<V8LocalValue<'isolate_scope, 'isolate>, Error = &'static str>,
 {
     type Error = &'static str;
     fn try_from(
-        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>,
+        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>,
     ) -> Result<Self, Self::Error> {
         let mut res = Self::new();
         for v in val {
@@ -473,13 +528,13 @@ where
     }
 }
 
-impl<'isolate_scope, 'isolate, 'a>
-    TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>>
+impl<'isolate_scope, 'isolate, 'ctx_scope, 'a>
+    TryFrom<&mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>>
     for Vec<V8LocalValue<'isolate_scope, 'isolate>>
 {
     type Error = &'static str;
     fn try_from(
-        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'a>,
+        val: &mut V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>,
     ) -> Result<Self, Self::Error> {
         Ok(val.collect())
     }

--- a/src/v8/v8_value.rs
+++ b/src/v8/v8_value.rs
@@ -148,7 +148,6 @@ impl<'isolate_scope, 'isolate> V8LocalValue<'isolate_scope, 'isolate> {
     }
 
     /// Return true if the value is null and false otherwise.
-    #[must_use]
     pub fn is_undefined(&self) -> bool {
         (unsafe { v8_ValueIsUndefined(self.inner_val) } != 0)
     }

--- a/v8-rs-derive/Cargo.toml
+++ b/v8-rs-derive/Cargo.toml
@@ -8,7 +8,10 @@ edition = "2021"
 [dependencies]
 syn = { version="1.0", features = ["full"]}
 quote = "1.0"
-v8_rs = { path = "../" }
+v8_rs = { path = "../", optional = true }
+
+[features]
+docs = ["v8_rs"]
 
 [lib]
 name = "v8_derive"

--- a/v8-rs-derive/Cargo.toml
+++ b/v8-rs-derive/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 syn = { version="1.0", features = ["full"]}
 quote = "1.0"
+v8_rs = { path = "../" }
 
 [lib]
 name = "v8_derive"

--- a/v8-rs-derive/src/lib.rs
+++ b/v8-rs-derive/src/lib.rs
@@ -13,10 +13,8 @@ use syn::Fields;
 use syn::GenericArgument;
 use syn::PathArguments;
 
-/// This derive proc macro can be specified on a struct
-/// and provide the ability to automatically generate the
-/// struct from the native function JS argument.
-/// It should be used along side the `new_native_function` proc
+/// This derive proc macro can be specified on a struct and provide the ability to automatically generate the
+/// struct from the native function JS argument. It should be used along side the `new_native_function` proc
 /// macro in the following maner:
 ///
 /// ```rust,no_run,ignore
@@ -38,22 +36,32 @@ use syn::PathArguments;
 /// let native_function = isolate_scope.new_native_function_template(new_native_function!(|_isolate, _ctx_scope, args: Args| { /* put your code here */});
 /// ```
 ///
-/// The above example will automatically generate a code that
-/// takes the argument given from the JS and translate it to `Args`.
+/// The above example will automatically generate a code that takes the argument given from the JS and translate it to `Args`.
 ///
-/// This macro expect that the JS will pass a single
-/// JS object that matches the give struct. For example, the following
+/// This macro expect that the JS will pass a single JS object that matches the give struct. For example, the following
 /// JS object will match our `Args` struct:
 ///
 /// ```JS
 /// {i: 1, s: 'foo', b: false, inner: {i: 10} }
 /// ```
 ///
-/// Notice that any optional field is not mandatory and will be set
-/// to `None` if not given.
+/// Notice that any optional field is not mandatory and will be set to `None` if not given.
 ///
-/// And error will be raised if the given argument do not match the
-/// struct definition.
+/// And error will be raised if the given argument do not match the struct definition.
+///
+/// The following table demonstrate how JS objects are parsed into rust types:
+///
+/// | JS type        | rust type                 |
+/// |----------------|---------------------------|
+/// | `string`       | `String` | `V8LocalUtf8`  |
+/// | `array_buffer` | `V8LocalArrayBuffer`      |
+/// | `bool`         | `bool`                    |
+/// | `big integer`  | `i64`                     |
+/// | `number`       | `f64`                     |
+/// | `array`        | `V8LocalArray`            |
+/// | `map`          | `V8LocalObject`           |
+/// | `set`          | `V8LocalSet`              |
+///
 #[proc_macro_derive(NativeFunctionArgument)]
 pub fn object_argument(item: TokenStream) -> TokenStream {
     let struct_input: DeriveInput = parse_macro_input!(item);

--- a/v8-rs-derive/src/lib.rs
+++ b/v8-rs-derive/src/lib.rs
@@ -15,7 +15,7 @@ use syn::PathArguments;
 
 // those imports are used on docs so we will have them available
 // without them the docs links will be long and ugly.
-#[allow(unused_imports)]
+#[cfg(feature = "docs")]
 use v8_rs::v8::{
     v8_array::V8LocalArray, v8_array_buffer::V8LocalArrayBuffer, v8_object::V8LocalObject,
     v8_set::V8LocalSet, v8_utf8::V8LocalUtf8,

--- a/v8-rs-derive/src/lib.rs
+++ b/v8-rs-derive/src/lib.rs
@@ -53,14 +53,14 @@ use syn::PathArguments;
 ///
 /// | JS type        | rust type                 |
 /// |----------------|---------------------------|
-/// | `string`       | `String` | `V8LocalUtf8`  |
-/// | `array_buffer` | `V8LocalArrayBuffer`      |
-/// | `bool`         | `bool`                    |
-/// | `big integer`  | `i64`                     |
-/// | `number`       | `f64`                     |
-/// | `array`        | `V8LocalArray`            |
-/// | `map`          | `V8LocalObject`           |
-/// | `set`          | `V8LocalSet`              |
+/// | `string`       | [String] | [V8LocalUtf8]  |
+/// | `array_buffer` | [V8LocalArrayBuffer]      |
+/// | `bool`         | [bool]                    |
+/// | `big integer`  | [i64]                     |
+/// | `number`       | [f64]                     |
+/// | `array`        | [V8LocalArray]            |
+/// | `map`          | [V8LocalObject]           |
+/// | `set`          | [V8LocalSet]              |
 ///
 #[proc_macro_derive(NativeFunctionArgument)]
 pub fn object_argument(item: TokenStream) -> TokenStream {

--- a/v8-rs-derive/src/lib.rs
+++ b/v8-rs-derive/src/lib.rs
@@ -51,16 +51,16 @@ use syn::PathArguments;
 ///
 /// The following table demonstrate how JS objects are parsed into rust types:
 ///
-/// | JS type        | rust type                 |
-/// |----------------|---------------------------|
-/// | `string`       | [String] | [V8LocalUtf8]  |
-/// | `array_buffer` | [V8LocalArrayBuffer]      |
-/// | `bool`         | [bool]                    |
-/// | `big integer`  | [i64]                     |
-/// | `number`       | [f64]                     |
-/// | `array`        | [V8LocalArray]            |
-/// | `map`          | [V8LocalObject]           |
-/// | `set`          | [V8LocalSet]              |
+/// | JS type        | rust type                                             |
+/// |----------------|-------------------------------------------------------|
+/// | `string`       | [String] or [v8_rs::v8::v8_utf8::V8LocalUtf8]         |
+/// | `array_buffer` | [v8_rs::v8::v8_array_buffer::V8LocalArrayBuffer]      |
+/// | `bool`         | [bool]                                                |
+/// | `big integer`  | [i64]                                                 |
+/// | `number`       | [f64]                                                 |
+/// | `array`        | [v8_rs::v8::v8_array::V8LocalArray]                   |
+/// | `map`          | [v8_rs::v8::v8_object::V8LocalObject]                 |
+/// | `set`          | [v8_rs::v8::v8_set::V8LocalSet]                       |
 ///
 #[proc_macro_derive(NativeFunctionArgument)]
 pub fn object_argument(item: TokenStream) -> TokenStream {

--- a/v8-rs-derive/src/lib.rs
+++ b/v8-rs-derive/src/lib.rs
@@ -13,6 +13,14 @@ use syn::Fields;
 use syn::GenericArgument;
 use syn::PathArguments;
 
+// those imports are used on docs so we will have them available
+// without them the docs links will be long and ugly.
+#[allow(unused_imports)]
+use v8_rs::v8::{
+    v8_array::V8LocalArray, v8_array_buffer::V8LocalArrayBuffer, v8_object::V8LocalObject,
+    v8_set::V8LocalSet, v8_utf8::V8LocalUtf8,
+};
+
 /// This derive proc macro can be specified on a struct and provide the ability to automatically generate the
 /// struct from the native function JS argument. It should be used along side the `new_native_function` proc
 /// macro in the following maner:
@@ -53,14 +61,14 @@ use syn::PathArguments;
 ///
 /// | JS type        | rust type                                             |
 /// |----------------|-------------------------------------------------------|
-/// | `string`       | [String] or [v8_rs::v8::v8_utf8::V8LocalUtf8]         |
-/// | `array_buffer` | [v8_rs::v8::v8_array_buffer::V8LocalArrayBuffer]      |
+/// | `string`       | [String] or [V8LocalUtf8]                             |
+/// | `array_buffer` | [V8LocalArrayBuffer]                                  |
 /// | `bool`         | [bool]                                                |
 /// | `big integer`  | [i64]                                                 |
 /// | `number`       | [f64]                                                 |
-/// | `array`        | [v8_rs::v8::v8_array::V8LocalArray]                   |
-/// | `map`          | [v8_rs::v8::v8_object::V8LocalObject]                 |
-/// | `set`          | [v8_rs::v8::v8_set::V8LocalSet]                       |
+/// | `array`        | [V8LocalArray]                                        |
+/// | `map`          | [V8LocalObject]                                       |
+/// | `set`          | [V8LocalSet]                                          |
 ///
 #[proc_macro_derive(NativeFunctionArgument)]
 pub fn object_argument(item: TokenStream) -> TokenStream {

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1228,6 +1228,12 @@ v8_local_value* v8_ObjectToValue(v8_local_object *obj) {
 	return res;
 }
 
+v8_local_value* v8_ValueToValue(v8_local_value *val) {
+	v8_local_value *res = (v8_local_value*) V8_ALLOC(sizeof(*res));
+	res = new (res) v8_local_value(val->val);
+	return res;
+}
+
 v8_local_value* v8_ExternalDataToValue(v8_local_external_data *ext) {
 	v8::Local<v8::Value> val = v8::Local<v8::Value>::Cast(ext->ext);
 	v8_local_value *res = (v8_local_value*) V8_ALLOC(sizeof(*res));

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1304,6 +1304,10 @@ int v8_ValueIsNull(v8_local_value *val) {
 	return val->val->IsNull();
 }
 
+int v8_ValueIsUndefined(v8_local_value *val) {
+	return val->val->IsUndefined();
+}
+
 v8_local_array_buff* v8_NewArrayBuffer(v8_isolate *i, const char *data, size_t len) {
 	v8::Isolate *isolate = (v8::Isolate*)i;
 	v8::Local<v8::ArrayBuffer> arr_buff = v8::ArrayBuffer::New(isolate, len);

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -484,6 +484,9 @@ v8_local_value* v8_NewNull(v8_isolate *i);
 /* Return 1 if the given JS value is null 0 otherwise */
 int v8_ValueIsNull(v8_local_value *val);
 
+/* Return 1 if the given JS value is undefined 0 otherwise */
+int v8_ValueIsUndefined(v8_local_value *val);
+
 /* Create a js ArrayBuffer */
 v8_local_array_buff* v8_NewArrayBuffer(v8_isolate *i, const char *data, size_t len);
 

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -452,6 +452,9 @@ void v8_FreeExternalData(v8_local_external_data *ext);
 /* Convert the given JS object into JS generic value */
 v8_local_value* v8_ObjectToValue(v8_local_object *obj);
 
+/* Shellow copy of the given JS value. */
+v8_local_value* v8_ValueToValue(v8_local_value *obj);
+
 v8_local_value* v8_ExternalDataToValue(v8_local_external_data *ext);
 
 /* Create a new set */


### PR DESCRIPTION
The PR introduce a new derive proc macro that provides the ability to automatically generate the struct from the native function JS argument. It should be used along side the `new_native_function` proc macro in the following maner:

```rust
#[derive(NativeFunctionArgument)]
struct InnerArgs {
    i: i64,
}
#[derive(NativeFunctionArgument)]
struct Args {
    i: i64,
    s: String,
    b: bool,
    o: Option<String>,
    inner: InnerArgs,
    optional_inner: Option<InnerArgs>,
}
let native_function = isolate_scope.new_native_function_template(new_native_function!(|_isolate, _ctx_scope, args: Args| { /* put your code here */});
```

The above example will automatically generate a code that takes the argument given from the JS and translate it to `Args`. This macro expect that the JS will pass a single JS object that matches the give struct. For example, the following JS object will match our `Args` struct:

```JS
{i: 1, s: 'foo', b: false, inner: {i: 10} }
```

Notice that any optional field is not mandatory and will be set to `None` if not given. An error will be raised if the given JS argument do not matches the struct definition.