### PR TITLE
Support optional parameter on NativeFunctionArgument derive macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -930,6 +930,45 @@ mod json_path_tests {
     }
 
     #[test]
+    fn test_object_argument_macro_with_optional_argument() {
+        define_function_and_call(
+            "test({i: 1, s: 'foo', b: false, inner: { i: 10 }}, {i: 1, s: 'foo', b: false, inner: { i: 10 }})",
+            "test",
+            new_native_function!(|_isolate,
+                                  _ctx_scope,
+                                  args: Args,
+                                  optional_args1: Option<Args>,
+                                  optional_args2: Option<Args>| {
+                assert_eq!(
+                    args,
+                    Args {
+                        i: 1,
+                        s: "foo".to_owned(),
+                        b: false,
+                        o: None,
+                        inner: InnerArgs { i: 10 },
+                        optional_inner: None,
+                    },
+                );
+                assert_eq!(
+                    optional_args1,
+                    Some(Args {
+                        i: 1,
+                        s: "foo".to_owned(),
+                        b: false,
+                        o: None,
+                        inner: InnerArgs { i: 10 },
+                        optional_inner: None,
+                    }),
+                );
+                assert_eq!(optional_args2, None);
+                Result::<Option<v8_value::V8LocalValue>, String>::Ok(None)
+            }),
+        )
+        .expect("Got error on function run");
+    }
+
+    #[test]
     fn test_error_on_object_argument_macro() {
         let err = define_function_and_call(
             "test({i: 1, s: 'foo', b: false })",

--- a/v8-rs-derive/src/lib.rs
+++ b/v8-rs-derive/src/lib.rs
@@ -155,6 +155,19 @@ pub fn object_argument(item: TokenStream) -> TokenStream {
             }
         }
 
+        impl<'isolate_scope, 'isolate, 'ctx_scope, 'a> v8_rs::v8::OptionalTryFrom<&mut v8_rs::v8::v8_native_function_template::V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>> for #struct_name #generics {
+            type Error = String;
+
+            fn optional_try_from(it: &mut v8_rs::v8::v8_native_function_template::V8LocalNativeFunctionArgsIter<'isolate_scope, 'isolate, 'ctx_scope, 'a>) -> Result<Option<Self>, Self::Error> {
+                let val = match it.next() {
+                    Some(v) => v,
+                    None => return Ok(None),
+                };
+                let ctx_scope = it.get_ctx_scope();
+                v8_rs::v8::v8_value::V8CtxValue::new(&val, ctx_scope).try_into().map(|v| Some(v))
+            }
+        }
+
         impl<'isolate_scope, 'isolate, 'value, 'ctx_value> TryFrom<v8_rs::v8::v8_value::V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_value>> for #struct_name #generics {
             type Error = String;
 


### PR DESCRIPTION
The PR extends `NativeFunctionArgument` derive macro to also support and optional argument. So it will be possible to write the following native function and have the 2 last arguments as optional:

```rust
   #[derive(NativeFunctionArgument, PartialEq, Eq, Debug)]
    struct InnerArgs {
        i: i64,
    }

    #[derive(NativeFunctionArgument, PartialEq, Eq, Debug)]
    struct Args {
        i: i64,
        s: String,
        b: bool,
        o: Option<String>,
        inner: InnerArgs,
        optional_inner: Option<InnerArgs>,
    }

   new_native_function!(|_isolate, _ctx_scope, args: Args, optional_args1: Option<Args>,optional_args2: Option<Args>| {}
```

The following call will match to the above native function:

```js
test({i: 1, s: 'foo', b: false, inner: { i: 10 }}, {i: 1, s: 'foo', b: false, inner: { i: 10 }})
```

This is useful when we want to have a final argument as a optional JS object.