### PR TITLE
Fix use after free of native function return value.

### DIFF
--- a/src/v8/v8_module.rs
+++ b/src/v8/v8_module.rs
@@ -45,7 +45,13 @@ pub(crate) extern "C" fn load_module<
         inner_isolate: unsafe { v8_ContextRefGetIsolate(v8_ctx_ref) },
         no_release: true,
     };
-    let isolate_scope = V8IsolateScope::new(&isolate);
+
+    // We know that if we reach here we already entered the isolate and have a handlers scope, so
+    // we can and must create a dummy isolate scope. If we create a regular isolate scope
+    // all the local handlers will be free when this isolate scope will be release including the
+    // return value.
+    // Users can use this isolate score as if it was a regular isolate scope.
+    let isolate_scope = V8IsolateScope::new_dummy(&isolate);
     let ctx_scope = V8ContextScope {
         inner_ctx_ref: v8_ctx_ref,
         exit_on_drop: false,

--- a/src/v8/v8_native_function_template.rs
+++ b/src/v8/v8_native_function_template.rs
@@ -66,7 +66,12 @@ pub(crate) extern "C" fn native_basic_function<
         no_release: true,
     };
 
-    let isolate_scope = V8IsolateScope::new(&isolate);
+    // We know that if we reach here we already entered the isolate and have a handlers scope, so
+    // we can and must create a dummy isolate scope. If we create a regular isolate scope
+    // all the local handlers will be free when this isolate scope will be release including the
+    // return value.
+    // Users can use this isolate scope as if it was a regular isolate scope.
+    let isolate_scope = V8IsolateScope::new_dummy(&isolate);
 
     let inner_ctx_ref = unsafe { v8_GetCurrentCtxRef(inner_isolate) };
     let ctx_scope = V8ContextScope {


### PR DESCRIPTION
When we call a native function we should avoid creating a new isolate scope because when the isolate scope will be freed, all the local handlers will be marked for GC and potenatially freed as well. This includes the return value.

To avoid that, we create a dummy isolate scope. From user POV, the dummy isolate scope can be used like a regular isolate scope, But it will not cause local handler to be freed when it is released.