### PR TITLE
Add the API for the V8 Inspector.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 .vscode/*
 *.o
 *.a
+
+# Debugging history.
+.gdb_history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,13 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tungstenite = { version = "0.19", optional = true }
+log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.65"
 vergen = { version = "8", features = ["git", "gitcl"] }
 lazy_static = "1"
 
@@ -20,3 +24,7 @@ v8_rs_derive = { path = "./v8-rs-derive/"}
 name = "v8_rs"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["debug-server"]
+debug-server = ["tungstenite"]

--- a/README.md
+++ b/README.md
@@ -1,40 +1,37 @@
 # v8-rs
-Rust wrapper for v8
+Rust wrapper for the [Google V8 JavaScript Engine](https://chromium.googlesource.com/v8/v8).
 
-Example:
+## Example:
 
 ```rust
-use crate::v8::*;
+use v8_rs::v8::*;
 
-// initialized v8
-v8_init();
+// Initialise the V8 engine:
+v8_init(1);
 
-// Create a new isolate
+// Create a new isolate:
 let isolate = isolate::V8Isolate::new();
 
-// Create a new isolate scope
-let _h_scope = isolate.new_handlers_scope();
-
-// Enter the isolate
+// Enter the isolate created:
 let i_scope = isolate.enter();
 
-// Create the code string object
-let code_str = isolate.new_string("1+1");
+// Create the code string object:
+let code_str = i_scope.new_string("1+1");
 
-// Create a JS context for code invocation.
+// Create a JS execution context for code invocation:""
 let ctx = i_scope.new_context(None);
 
-// Enter the created context
-let ctx_scope = ctx.enter();
+// Enter the created execution context:
+let ctx_scope = ctx.enter(&i_scope);
 
-// Compile the code
+// Compile the code:
 let script = ctx_scope.compile(&code_str).unwrap();
 
-// Run the code
+// Run the compiled code:
 let res = script.run(&ctx_scope).unwrap();
 
-// Get the result
-let res_utf8 = res.to_utf8(&isolate).unwrap();
+// Get the result:
+let res_utf8 = res.to_utf8().unwrap();
 assert_eq!(res_utf8.as_str(), "2");
 ```
 
@@ -42,11 +39,11 @@ assert_eq!(res_utf8.as_str(), "2");
 
 Usually, just adding the crate as a dependency in your project will be enough. That said it is possible to change the following build option using evironment variables.
 
-* V8_VERSION - will change the default V8 version to use.
-* V8_UPDATE_HEADERS - will update the V8 headers according to the set version, allow to also set the following options:
-  * V8_HEADERS_PATH - control where to download the headers zip file, default `v8_c_api/libv8.include.zip`.
-  * V8_FORCE_DOWNLOAD_V8_HEADERS - download the V8 headers zip file even if it is already exists.
-  * V8_HEADERS_URL - url from where to download the V8 headers zip file.
-* V8_MONOLITH_PATH - control where to download the V8 monolith, default `v8_c_api/libv8_monolith.a`
-* V8_FORCE_DOWNLOAD_V8_MONOLITH - download the V8 monolith even if it is already exists.
-* V8_MONOLITH_URL - url from where to download the V8 monolith file.
+* `V8_VERSION` - will change the default V8 version to use.
+* `V8_UPDATE_HEADERS` - will update the V8 headers according to the set version, allow to also set the following options:
+  * `V8_HEADERS_PATH` - control where to download the headers zip file, default `v8_c_api/libv8.include.zip`.
+  * `V8_FORCE_DOWNLOAD_V8_HEADERS` - download the V8 headers zip file even if it is already exists.
+  * `V8_HEADERS_URL` - url from where to download the V8 headers zip file.
+* `V8_MONOLITH_PATH` - control where to download the V8 monolith, default `v8_c_api/libv8_monolith.a`
+* `V8_FORCE_DOWNLOAD_V8_MONOLITH` - download the V8 monolith even if it is already exists.
+* `V8_MONOLITH_URL` - url from where to download the V8 monolith file.

--- a/src/v8/inspector/messages.rs
+++ b/src/v8/inspector/messages.rs
@@ -1,0 +1,115 @@
+/*
+ * Copyright Redis Ltd. 2022 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+//! The messages the V8 Inspector, represented by [super::Inspector],
+//! sends and receives.
+//!
+//! See [ClientMessage], [MethodInvocation], [ServerMessage],
+//! and [ErrorMessage].
+use serde::{Deserialize, Serialize};
+
+/// A method invocation message.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MethodInvocation {
+    /// The name of the method.
+    #[serde(rename = "method")]
+    pub name: String,
+    /// The parameters to pass to the method.
+    #[serde(rename = "params")]
+    pub arguments: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A message from the debugger front-end (from the client to the
+/// server).
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ClientMessage {
+    /// The ID of the message.
+    pub id: u64,
+    /// The method information.
+    #[serde(flatten)]
+    pub method: MethodInvocation,
+}
+
+impl ClientMessage {
+    /// The V8 method which is invoked when a client has successfully
+    /// connected to the [super::Inspector] server and waits for the
+    /// debugging session to start.
+    const DEBUGGER_SHOULD_START_METHOD_NAME: &str = "Runtime.runIfWaitingForDebugger";
+
+    /// Creates a new client message which says that the remote debugger
+    /// (the client) is ready to proceed.
+    pub fn new_client_ready(id: u64) -> Self {
+        Self {
+            id,
+            method: MethodInvocation {
+                name: Self::DEBUGGER_SHOULD_START_METHOD_NAME.to_owned(),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Creates a new client message which instructs the [Inspector] to
+    /// set a breakpoint.
+    pub fn new_breakpoint(id: u64, column: u64, line: u64, url: &str) -> Self {
+        const SET_BREAKPOINT_METHOD_NAME: &str = "Debugger.setBreakpointByUrl";
+        // Example: { id: 1015, method: MethodInvocation { name: "Debugger.setBreakpointByUrl",
+        // arguments: {"columnNumber": Number(0), "lineNumber": Number(0),
+        // "urlRegex": String("file:\\/\\/\\/home\\/fx\\/workspace\\/RedisGears\\/redisgears_core\\/src\\/lib\\.rs($|\\?)|\\/home\\/fx\\/workspace\\/RedisGears\\/redisgears_core\\/src\\/lib\\.rs($|\\?)")} } }
+
+        let mut arguments = serde_json::Map::new();
+        arguments.insert("columnNumber".to_owned(), serde_json::json!(column));
+        arguments.insert("lineNumber".to_owned(), serde_json::json!(line));
+        arguments.insert("urlRegex".to_owned(), serde_json::json!(url));
+
+        Self {
+            id,
+            method: MethodInvocation {
+                name: SET_BREAKPOINT_METHOD_NAME.to_owned(),
+                arguments,
+            },
+        }
+    }
+
+    /// Returns `true` if the message says that the remote debugger
+    /// (the client) is ready to proceed.
+    pub fn is_client_ready(&self) -> bool {
+        self.method.name == Self::DEBUGGER_SHOULD_START_METHOD_NAME
+    }
+}
+
+/// An error message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorMessage {
+    /// The error code.
+    pub code: i32,
+    /// The error message.
+    pub message: String,
+}
+
+/// A message from the server to the client (from the back-end to the
+/// front-end).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerMessage {
+    /// In case the error occurs on the [super::Inspector] side, a
+    /// message of this variant is sent to the client.
+    Error {
+        /// The object containing the [super::Inspector] error message.
+        error: ErrorMessage,
+    },
+    /// The [super::Inspector] sends such sort of messages when it wants
+    /// to execute a remote method.
+    Invoke(MethodInvocation),
+    /// Such kind of messages are sent from the [super::Inspector] to
+    /// the remote client as a result of previous message, identifiable
+    /// by the `id` member.
+    Result {
+        /// The ID of the previous message in chain to which this is
+        /// the answer.
+        id: u64,
+        /// The result of the message processing.
+        result: serde_json::Map<String, serde_json::Value>,
+    },
+}

--- a/src/v8/inspector/mod.rs
+++ b/src/v8/inspector/mod.rs
@@ -1,0 +1,303 @@
+/*
+ * Copyright Redis Ltd. 2022 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+//! The [Inspector] is a helpful facility for remote debugging of the
+//! JavaScript code provided by the V8 engine.
+//!
+//! To be able to debug, an inspector must be created and supplied with
+//! the remote debugger's requests. To answer back, the `on_response`
+//! callback must be properly set.
+//!
+//! # Sessions
+//!
+//! To be able to debug remotely, a server is required. Here one may
+//! find the [server::WebSocketServer] useful. The
+//! [server::WebSocketServer] is a very simple WebSocket server, which
+//! can be used with an [Inspector].
+//!
+//! To start a debugging server session, it is required to have a
+//! [V8ContextScope], a [server::WebSocketServer] and an [Inspector].
+//! All of those are gently packed within an easy-to-use
+//! [server::DebuggerSession] struct which abstracts all the work. It is
+//! a scoped object, meaning that once an object of
+//! [server::DebuggerSession] leaves its scope, the debugger server and
+//! the debugging session are stopped.
+//!
+//! In case the `"debug-server"` feature isn't enabled, the user of the
+//! crate must manually provide a way to receive and send messages over
+//! the network and feed the [Inspector] with data.
+use std::marker::PhantomData;
+
+pub mod messages;
+#[cfg(feature = "debug-server")]
+pub mod server;
+
+use crate::v8::v8_context_scope::V8ContextScope;
+
+/// The callback which is invoked when the V8 Inspector needs to reply
+/// to the client.
+type OnResponseCallback = dyn FnMut(String);
+
+/// The callback which is invoked when the V8 Inspector requires more
+/// data from the front-end (the client) and, therefore, this callback
+/// must attempt to read more data and dispatch it to the inspector.
+///
+/// The callback should return `1` when it is possible to operate (read,
+/// write, send, receive messages) and `0` when not, to indicate the
+/// impossibility of the further action, in which case, the inspector
+/// will stop.
+type OnWaitFrontendMessageOnPauseCallback =
+    dyn FnMut(*mut crate::v8_c_raw::bindings::v8_inspector_c_wrapper) -> std::os::raw::c_int;
+
+/// The debugging inspector, carefully wrapping the
+/// [`v8_inspector::Inspector`](https://chromium.googlesource.com/v8/v8/+/refs/heads/main/src/inspector)
+/// API.
+pub struct Inspector<'context_scope, 'isolate_scope, 'isolate> {
+    raw: *mut crate::v8_c_raw::bindings::v8_inspector_c_wrapper,
+    /// This callback is stored to preserve the lifetime, it is never
+    /// called by this object, but by the C++ side.
+    _on_response_callback: Option<Box<Box<OnResponseCallback>>>,
+    /// This callback is stored to preserve the lifetime, it is never
+    /// called by this object, but by the C++ side.
+    _on_wait_frontend_message_on_pause_callback:
+        Option<Box<Box<OnWaitFrontendMessageOnPauseCallback>>>,
+    /// The lifetime holder.
+    _phantom_data: PhantomData<&'context_scope V8ContextScope<'isolate_scope, 'isolate>>,
+}
+
+impl<'context_scope, 'isolate_scope, 'isolate> std::fmt::Debug
+    for Inspector<'context_scope, 'isolate_scope, 'isolate>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let on_response_str = if let Some(ref callback) = self._on_response_callback {
+            format!("Some({callback:p})")
+        } else {
+            "None".to_owned()
+        };
+
+        let on_wait_str =
+            if let Some(ref callback) = self._on_wait_frontend_message_on_pause_callback {
+                format!("Some({callback:p})")
+            } else {
+                "None".to_owned()
+            };
+
+        f.debug_struct("Inspector")
+            .field("raw", &self.raw)
+            .field("_on_response_callback", &on_response_str)
+            .field("_on_wait_frontend_message_on_pause_callback", &on_wait_str)
+            .finish()
+    }
+}
+
+/// The callback function used to send the messages back to the client
+/// of the inspector (to the one who is debugging).
+extern "C" fn on_response(
+    string: *const ::std::os::raw::c_char,
+    rust_callback: *mut ::std::os::raw::c_void,
+) {
+    let string = unsafe { std::ffi::CStr::from_ptr(string) }.to_string_lossy();
+    log::trace!("Outgoing message: {string}");
+    let rust_callback: &mut Box<OnResponseCallback> = unsafe {
+        &mut *(rust_callback as *mut std::boxed::Box<dyn std::ops::FnMut(std::string::String)>)
+    };
+    rust_callback(string.to_string())
+}
+
+extern "C" fn on_wait_frontend_message_on_pause(
+    raw: *mut crate::v8_c_raw::bindings::v8_inspector_c_wrapper,
+    rust_callback: *mut ::std::os::raw::c_void,
+) -> ::std::os::raw::c_int {
+    log::trace!("on_wait_frontend_message_on_pause");
+    let rust_callback: &mut Box<OnWaitFrontendMessageOnPauseCallback> = unsafe {
+        &mut *(rust_callback
+            as *mut std::boxed::Box<
+                dyn std::ops::FnMut(*mut crate::v8_c_raw::bindings::v8_inspector_c_wrapper) -> i32,
+            >)
+    };
+    rust_callback(raw)
+}
+
+impl<'context_scope, 'isolate_scope, 'isolate> Inspector<'context_scope, 'isolate_scope, 'isolate> {
+    /// Creates a new [Inspector].
+    pub fn new(
+        context: &'context_scope V8ContextScope<'isolate_scope, 'isolate>,
+        on_response_callback: Box<OnResponseCallback>,
+        on_wait_frontend_message_on_pause_callback: Box<OnWaitFrontendMessageOnPauseCallback>,
+    ) -> Self {
+        let on_response_callback = Box::new(on_response_callback);
+        let on_response_callback = Box::into_raw(on_response_callback);
+        let on_wait_frontend_message_on_pause_callback =
+            Box::new(on_wait_frontend_message_on_pause_callback);
+        let on_wait_frontend_message_on_pause_callback =
+            Box::into_raw(on_wait_frontend_message_on_pause_callback);
+
+        let raw = unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorCreate(
+                context.inner_ctx_ref,
+                Some(on_response),
+                on_response_callback as _,
+                Some(on_wait_frontend_message_on_pause),
+                on_wait_frontend_message_on_pause_callback as _,
+            )
+        };
+
+        let on_response_callback: Box<Box<dyn FnMut(String)>> =
+            unsafe { Box::from_raw(on_response_callback as *mut _) };
+        let on_wait_frontend_message_on_pause_callback =
+            unsafe { Box::from_raw(on_wait_frontend_message_on_pause_callback as *mut _) };
+        Self {
+            raw,
+            _on_response_callback: Some(on_response_callback),
+            _on_wait_frontend_message_on_pause_callback: Some(
+                on_wait_frontend_message_on_pause_callback,
+            ),
+            _phantom_data: PhantomData,
+        }
+    }
+
+    /// Creates a new [Inspector] without any callbacks set. Such an
+    /// inspector can't be used for debugging purposes, but the
+    /// callbacks can be set later via
+    /// [Inspector::set_on_wait_frontend_message_on_pause_callback] and
+    /// [Inspector::set_on_response_callback]. Without the callbacks,
+    /// the inspector attaches to the `V8Platform` and the `V8Context`,
+    /// while the proper hooks (callbacks) can be set later when the
+    /// debugging process should actually take place.
+    pub fn new_without_callbacks(
+        context: &'context_scope V8ContextScope<'isolate_scope, 'isolate>,
+    ) -> Self {
+        let raw = unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorCreate(
+                context.inner_ctx_ref,
+                None,
+                std::ptr::null_mut(),
+                None,
+                std::ptr::null_mut(),
+            )
+        };
+        Self {
+            raw,
+            _on_response_callback: None,
+            _on_wait_frontend_message_on_pause_callback: None,
+            _phantom_data: PhantomData,
+        }
+    }
+
+    /// Sets the callback which is used by the debugger to send messages
+    /// to the remote client.
+    pub fn set_on_response_callback(&mut self, on_response_callback: Box<OnResponseCallback>) {
+        let on_response_callback = Box::new(on_response_callback);
+        let on_response_callback = Box::into_raw(on_response_callback);
+
+        unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorSetOnResponseCallback(
+                self.raw,
+                Some(on_response),
+                on_response_callback as _,
+            );
+        }
+
+        let on_response_callback = unsafe { Box::from_raw(on_response_callback as *mut _) };
+        self._on_response_callback = Some(on_response_callback);
+    }
+
+    /// Sets the callback when the debugger needs to wait for the
+    /// remote client's message.
+    pub fn set_on_wait_frontend_message_on_pause_callback(
+        &mut self,
+        on_wait_frontend_message_on_pause_callback: Box<OnWaitFrontendMessageOnPauseCallback>,
+    ) {
+        let on_wait_frontend_message_on_pause_callback =
+            Box::new(on_wait_frontend_message_on_pause_callback);
+        let on_wait_frontend_message_on_pause_callback =
+            Box::into_raw(on_wait_frontend_message_on_pause_callback);
+
+        unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorSetOnWaitFrontendMessageOnPauseCallback(
+                self.raw,
+                Some(on_wait_frontend_message_on_pause),
+                on_wait_frontend_message_on_pause_callback as _,
+            );
+        }
+
+        let on_wait_frontend_message_on_pause_callback =
+            unsafe { Box::from_raw(on_wait_frontend_message_on_pause_callback as *mut _) };
+        self._on_wait_frontend_message_on_pause_callback =
+            Some(on_wait_frontend_message_on_pause_callback);
+    }
+
+    /// Resets the `onResponse` callback. See
+    /// [Self::set_on_response_callback].
+    pub fn reset_on_response_callback(&mut self) {
+        unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorSetOnResponseCallback(
+                self.raw,
+                None,
+                std::ptr::null_mut(),
+            );
+        }
+        self._on_response_callback = None;
+    }
+
+    /// Resets the `onWaitFrontendMessageOnPause` callback. See
+    /// [Self::set_on_wait_frontend_message_on_pause_callback].
+    pub fn reset_on_wait_frontend_message_on_pause_callback(&mut self) {
+        unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorSetOnWaitFrontendMessageOnPauseCallback(
+                self.raw,
+                None,
+                std::ptr::null_mut(),
+            );
+        }
+        self._on_wait_frontend_message_on_pause_callback = None;
+    }
+
+    /// Dispatches the Chrome Developer Tools (CDT) protocol message.
+    pub fn dispatch_protocol_message<T: AsRef<str>>(&self, message: T) {
+        let message = message.as_ref();
+
+        let string = match std::ffi::CString::new(message) {
+            Ok(string) => string,
+            _ => return,
+        };
+        unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorDispatchProtocolMessage(
+                self.raw,
+                string.as_ptr(),
+            )
+        }
+    }
+
+    /// Schedules a debugger pause (sets a breakpoint) for the next
+    /// statement.
+    pub fn schedule_pause_on_next_statement<T: AsRef<str>>(&self, reason: T) {
+        let string = match std::ffi::CString::new(reason.as_ref()) {
+            Ok(string) => string,
+            _ => return,
+        };
+        unsafe {
+            crate::v8_c_raw::bindings::v8_InspectorSchedulePauseOnNextStatement(
+                self.raw,
+                string.as_ptr(),
+            )
+        }
+    }
+
+    /// Enables the debugger main loop.
+    pub fn wait_frontend_message_on_pause(&self) {
+        unsafe { crate::v8_c_raw::bindings::v8_InspectorWaitFrontendMessageOnPause(self.raw) }
+    }
+}
+
+impl<'context_scope, 'isolate_scope, 'isolate> Drop
+    for Inspector<'context_scope, 'isolate_scope, 'isolate>
+{
+    fn drop(&mut self) {
+        unsafe {
+            crate::v8_c_raw::bindings::v8_FreeInspector(self.raw as *mut _);
+        }
+    }
+}

--- a/src/v8/inspector/server.rs
+++ b/src/v8/inspector/server.rs
@@ -1,0 +1,616 @@
+/*
+ * Copyright Redis Ltd. 2022 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+//! This module provides with the debug server structures. With these
+//! structures it is possibly to easily start a debug server and start
+//! processing remote debuggers' messages over the network. The module
+//! implements messaging via the `WebSocket` protocol, as it is mainly
+//! used together with Chrome V8 engine for debugging, however, the
+//! implementation is platform-agnostic and one can use any sort of
+//! transport for the messages.
+//!
+//! # Clients
+//!
+//! To connect to a remote debugging WebSocket server, one can use:
+//!
+//! 1. A custom web-socket client, and some implementation of the
+//! V8 Inspector protocol.
+//! 2. The chrome-devtools, for example, by running the chromium
+//! web-browser and navigating to
+//! <devtools://devtools/bundled/inspector.html?ws=ip:port> where
+//! the `ip`/`port` parameters are the corresponding ip address and port
+//! of the [WebSocketServer] used.
+//! 3. (Needs verification) Using the WebKit MiniBrowser
+//! <https://trac.webkit.org/wiki/RemoteInspectorGTKandWPE>.
+//! 4. Using the V8's [D8 console debugger](https://v8.dev/docs/d8).
+//! 5. Using the [Visual Studio Code](https://code.visualstudio.com/),
+//! for example, using a configuration like this:
+//!     ```json
+//!     {
+//!         "version": "0.2.0",
+//!         "configurations": [
+//!             {
+//!                 "name": "Attach to RedisGears V8 on port 9005",
+//!                 "type": "node",
+//!                 "request": "attach",
+//!                 "cwd": "${workspaceFolder}",
+//!                 "websocketAddress": "ws://127.0.0.1:9005",
+//!             }
+//!         ]
+//!     }
+//!     ```
+//!
+//! # Example
+//!
+//! To debug, we must properly initialise the V8 and have a context
+//! scope ([super::V8ContextScope]), on which we can create an
+//! inspector.
+//!
+//! An inspector is just a hook into the `V8Platform` spying on the
+//! actions inside the [crate::v8::v8_context::V8Context] and which
+//! can pause, inspect and continue the execution.
+//!
+//! ```rust
+//! use v8_rs::v8::*;
+//! use inspector::messages::ClientMessage;
+//! use inspector::server::DebuggerSession;
+//! use std::sync::{Arc, Mutex};
+//!
+//! // Initialise the V8 engine:
+//! v8_init(1);
+//!
+//! // Create a new isolate:
+//! let isolate = isolate::V8Isolate::new();
+//!
+//! // Enter the isolate created:
+//! let i_scope = isolate.enter();
+//!
+//! // Create the code string object:
+//! let code_str = i_scope.new_string("1+1");
+//!
+//! // Create a JS execution context for code invocation:""
+//! let ctx = i_scope.new_context(None);
+//!
+//! // Enter the created execution context:
+//! let ctx_scope = ctx.enter(&i_scope);
+//!
+//! // Create an inspector.
+//! let mut inspector = ctx_scope.new_inspector();
+//!
+//! let mut stage_1 = Arc::new(Mutex::new(()));
+//! let mut stage_2 = Arc::new(Mutex::new(()));
+//!
+//! let lock_1 = stage_1.lock().unwrap();
+//! let lock_2 = stage_2.lock().unwrap();
+//!
+//! // The remote debugging server port for the [WebSocketServer].
+//! const PORT_V4: u16 = 9005;
+//! // The remote debugging server ip address for the [WebSocketServer].
+//! const IP_V4: std::net::Ipv4Addr = std::net::Ipv4Addr::LOCALHOST;
+//! // The full remote debugging server host name for the [WebSocketServer].
+//! const LOCAL_HOST: std::net::SocketAddrV4 =
+//!     std::net::SocketAddrV4::new(IP_V4, PORT_V4);
+//!
+//! let address = LOCAL_HOST.to_string();
+//! let address = &address;
+//!
+//! let fake_client = {
+//!     use std::net::TcpStream;
+//!     use tungstenite::protocol::{WebSocket, Message};
+//!     use tungstenite::stream::MaybeTlsStream;
+//!
+//!     let address = address.clone();
+//!     let stage_1 = stage_1.clone();
+//!
+//!     #[derive(Copy, Clone, Default, Debug)]
+//!     struct Client {
+//!         last_message_id: u64,
+//!     }
+//!     impl Client {
+//!         fn send_ready(
+//!             &mut self,
+//!             ws: &mut WebSocket<MaybeTlsStream<TcpStream>>
+//!         ) {
+//!             let message = ClientMessage::new_client_ready(self.last_message_id);
+//!             let message = Message::Text(serde_json::to_string(&message).unwrap());
+//!             ws.write_message(message).expect("Couldn't send the message");
+//!         }
+//!     }
+//!
+//!     std::thread::spawn(move || {
+//!         let mut ws: WebSocket<MaybeTlsStream<TcpStream>>;
+//!         loop {
+//!             match tungstenite::connect(format!("ws://{address}")) {
+//!                 Ok(s) => { ws = s.0; break; },
+//!                 _ => continue,
+//!             }
+//!         };
+//!         let mut client = Client::default();
+//!         client.send_ready(&mut ws);
+//!         let _ = ws.read_message();
+//!         drop(stage_1.lock().expect("Couldn't lock the stage 1"));
+//!         ws.close(None).expect("Couldn't close the WebSocket");
+//!     })
+//! };
+//!
+//! // Create the debugging server on the default host.
+//! let debugger_session = DebuggerSession::new(&mut inspector, address).unwrap();
+//!
+//! // At this point, the server is running and has accepted a remote
+//! // client. Once the client connects, the debugger pauses on the very
+//! // first (next) instruction, so we can safely attempt to run the
+//! // script, as it won't actually run but will wait for remote client
+//! // to act.
+//!
+//! // Compile the code:
+//! let script = ctx_scope.compile(&code_str).unwrap();
+//!
+//! // Allow the fake client to stop (for this test not to hang).
+//! drop(lock_1);
+//!
+//! // Run the compiled code:
+//! let res = script.run(&ctx_scope).unwrap();
+//!
+//! // To let the remote debugger operate, we need to be able to send
+//! // and receive data to and from it. This is achieved by starting the
+//! // main loop of the debugger session:
+//! assert!(debugger_session.process_messages().is_ok());
+//!
+//! fake_client.join();
+//!
+//! // Get the result:
+//! let res_utf8 = res.to_utf8().unwrap();
+//! assert_eq!(res_utf8.as_str(), "2");
+//! ```
+use std::net::{TcpListener, TcpStream};
+use std::rc::Rc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tungstenite::{Error, Message, WebSocket};
+
+use crate::v8::inspector::messages::ClientMessage;
+
+use super::{Inspector, OnResponseCallback, OnWaitFrontendMessageOnPauseCallback};
+
+/// The debugging server which waits for a connection of a remote
+/// debugger, receives messages from there and sends the replies back.
+#[derive(Debug)]
+struct TcpServer {
+    /// The server that accepts remote debugging connections.
+    server: TcpListener,
+}
+
+impl TcpServer {
+    /// Creates a new [TcpServer] object with a tcp listener to the specified
+    /// address.
+    pub fn new<T: std::net::ToSocketAddrs>(address: T) -> Result<Self, std::io::Error> {
+        let server = TcpListener::bind(address)?;
+        Ok(Self { server })
+    }
+
+    /// Returns the currently listening address.
+    pub fn get_listening_address(&self) -> Result<std::net::SocketAddr, std::io::Error> {
+        self.server.local_addr()
+    }
+
+    /// Starts listening for and a new single websocket connection.
+    /// Once the connection is accepted, it is returned to the user.
+    pub fn accept_next_websocket_connection(&self) -> Result<WebSocketServer, std::io::Error> {
+        tungstenite::accept(self.server.accept()?.0)
+            .map(WebSocketServer::from)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    }
+}
+
+/// A WebSocket server.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct WebSocketServer(WebSocket<TcpStream>);
+impl WebSocketServer {
+    /// The default read timeout duration.
+    const DEFAULT_READ_TIMEOUT_DURATION: Duration = Duration::from_millis(100);
+
+    /// Waits for a message available to read, and once there is one,
+    /// reads it and returns as a text.
+    pub fn read_next_message(&mut self) -> Result<String, std::io::Error> {
+        log::trace!("Reading the next message.");
+        match self.0.read_message() {
+            Ok(message) => message
+                .into_text()
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+            Err(Error::Io(e)) => Err(e),
+            Err(Error::ConnectionClosed | Error::AlreadyClosed) => Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "The WebSocket connection has been closed.",
+            )),
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+        }
+    }
+}
+
+impl From<WebSocket<TcpStream>> for WebSocketServer {
+    fn from(value: WebSocket<TcpStream>) -> Self {
+        value
+            .get_ref()
+            .set_read_timeout(Some(Self::DEFAULT_READ_TIMEOUT_DURATION))
+            .expect("Couldn't set the read timeout.");
+
+        Self(value)
+    }
+}
+
+struct InspectorCallbacks {
+    on_response: Box<OnResponseCallback>,
+    on_wait_frontend_message_on_pause: Box<OnWaitFrontendMessageOnPauseCallback>,
+}
+
+/// A single debugger session.
+#[derive(Debug)]
+pub struct DebuggerSession<'inspector, 'context_scope, 'isolate_scope, 'isolate> {
+    web_socket: Rc<Mutex<WebSocketServer>>,
+    inspector: &'inspector mut Inspector<'context_scope, 'isolate_scope, 'isolate>,
+}
+
+impl<'inspector, 'context_scope, 'isolate_scope, 'isolate>
+    DebuggerSession<'inspector, 'context_scope, 'isolate_scope, 'isolate>
+{
+    fn create_inspector_callbacks(web_socket: Rc<Mutex<WebSocketServer>>) -> InspectorCallbacks {
+        let websocket = web_socket.clone();
+
+        let on_response = move |s: String| {
+            log::trace!("Responding with string {s}.");
+            match websocket.lock() {
+                Ok(mut websocket) => match websocket.0.write_message(Message::Text(s)) {
+                    Ok(_) => log::trace!("Responded with string successfully."),
+                    Err(e) => log::error!("Couldn't send a websocket message to the client: {e}"),
+                },
+                Err(e) => log::error!("Couldn't lock the socket: {e}"),
+            }
+        };
+
+        let on_wait_frontend_message_on_pause = move |raw: *mut crate::v8_c_raw::bindings::v8_inspector_c_wrapper| -> std::os::raw::c_int {
+            let string;
+
+            loop {
+                match web_socket.lock() {
+                    Ok(mut websocket) => match websocket.read_next_message() {
+                        Ok(message) => {
+                            log::trace!("[OnWait] Read the message: {message:?}");
+
+                            string = match std::ffi::CString::new(message) {
+                                Ok(string) => string,
+                                _ => continue,
+                            };
+                            break;
+                        }
+                        Err(e) => if e.kind() == std::io::ErrorKind::ConnectionAborted {
+                            return 0;
+                        }
+                    },
+                    Err(e) => {
+                        log::error!("The WebSocketServer mutex is poisoned: {e:?}");
+                        return 0;
+                    },
+                }
+            }
+
+            unsafe {
+                crate::v8_c_raw::bindings::v8_InspectorDispatchProtocolMessage(
+                    raw,
+                    string.as_ptr(),
+                )
+            }
+
+            1
+        };
+
+        InspectorCallbacks {
+            on_response: Box::new(on_response),
+            on_wait_frontend_message_on_pause: Box::new(on_wait_frontend_message_on_pause),
+        }
+    }
+
+    /// Creates a new debugger to be used with the provided [Inspector].
+    /// Starts a web socket debugging session using [WebSocketServer].
+    ///
+    /// Once the connection is accepted and the inspector starts, the
+    /// function returns.
+    ///
+    /// After the function returns, to start the debugging main loop,
+    /// one needs to call the [Self::process_messages].
+    /// method.
+    pub fn new<T: std::net::ToSocketAddrs>(
+        inspector: &'inspector mut Inspector<'context_scope, 'isolate_scope, 'isolate>,
+        address: T,
+    ) -> Result<Self, std::io::Error> {
+        let server = TcpServer::new(address)?;
+        let address = server.get_listening_address()?;
+        let vscode_configuration = format!(
+            r#"
+        {{
+            "version": "0.2.0",
+            "configurations": [
+                {{
+                    "name": "Attach to RedisGears V8 through WebSocket at {address}",
+                    "type": "node",
+                    "request": "attach",
+                    "cwd": "${{workspaceFolder}}",
+                    "websocketAddress": "ws://{address}",
+                }}
+            ]
+        }}
+        "#
+        );
+        log::info!(
+            "The V8 remote debugging server is waiting for a connection via WebSocket on: {address}.\nHint: you may browse this link: <devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws={address}> or use this launch configuration for Visual Studio Code (<https://code.visualstudio.com/>):{vscode_configuration}",
+        );
+
+        let web_socket = Rc::new(Mutex::new(server.accept_next_websocket_connection()?));
+        log::trace!("Accepted the next websocket.");
+
+        let callbacks = Self::create_inspector_callbacks(web_socket.clone());
+
+        inspector.set_on_response_callback(callbacks.on_response);
+        inspector.set_on_wait_frontend_message_on_pause_callback(
+            callbacks.on_wait_frontend_message_on_pause,
+        );
+
+        let session = Self {
+            web_socket,
+            inspector,
+        };
+
+        // The re-locking read loop to wait until the remote debugger
+        // is ready to start.
+        loop {
+            let message_string: String = session.read_next_message()?;
+            let message: ClientMessage = match serde_json::from_str(&message_string) {
+                Ok(message) => message,
+                Err(_) => continue,
+            };
+            log::trace!("Parsed out the incoming message: {message:?}");
+            session.inspector.dispatch_protocol_message(&message_string);
+
+            if message.is_client_ready() {
+                session
+                    .inspector
+                    .schedule_pause_on_next_statement("Debugger started.");
+                session.inspector.wait_frontend_message_on_pause();
+
+                return Ok(session);
+            }
+        }
+    }
+
+    /// Reads the next message without parsing it.
+    pub fn read_next_message(&self) -> Result<String, std::io::Error> {
+        loop {
+            if let Ok(mut websocket) = self.web_socket.lock() {
+                match websocket.read_next_message() {
+                    Ok(s) => {
+                        if let Ok(None) = websocket.0.get_ref().read_timeout() {
+                            websocket
+                                .0
+                                .get_ref()
+                                .set_read_timeout(Some(
+                                    WebSocketServer::DEFAULT_READ_TIMEOUT_DURATION,
+                                ))
+                                .expect("Failed to temporarily reset the read timeout");
+                        }
+                        return Ok(s);
+                    }
+                    Err(e) => {
+                        if e.kind() == std::io::ErrorKind::TimedOut {
+                            continue;
+                        } else if e.kind() == std::io::ErrorKind::WouldBlock {
+                            websocket
+                                .0
+                                .get_ref()
+                                .set_read_timeout(None)
+                                .expect("Failed to temporarily reset the read timeout");
+                            log::trace!("Reset the timeout due to WouldBlock.");
+                            continue;
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                }
+            } else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "The mutex is poisoned.",
+                ));
+            }
+        }
+    }
+
+    /// Reads (without parsing), proccesses and then returns the next
+    /// message from the client.
+    pub fn read_and_process_next_message(&self) -> Result<String, std::io::Error> {
+        let message = self.read_next_message()?;
+        log::trace!("Got incoming websocket message: {message}");
+        self.inspector.dispatch_protocol_message(&message);
+        Ok(message)
+    }
+
+    /// Reads and processes all the next messages in a loop, until
+    /// the connection is dropped by the client or until an error state
+    /// is reached.
+    pub fn process_messages(&self) -> Result<(), std::io::Error> {
+        log::trace!("Inspector main loop started.");
+        loop {
+            if let Err(e) = self.read_and_process_next_message() {
+                if e.kind() == std::io::ErrorKind::ConnectionAborted {
+                    log::trace!("Inspector main loop successfully stopped.");
+                    return Ok(());
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Schedules a pause (sets a breakpoint) for the next statement.
+    /// See [super::Inspector::schedule_pause_on_next_statement].
+    pub fn schedule_pause_on_next_statement(&self) {
+        self.inspector
+            .schedule_pause_on_next_statement("User breakpoint.");
+    }
+}
+
+impl<'inspector, 'context_scope, 'isolate_scope, 'isolate> Drop
+    for DebuggerSession<'inspector, 'context_scope, 'isolate_scope, 'isolate>
+{
+    fn drop(&mut self) {
+        self.inspector.reset_on_response_callback();
+        self.inspector
+            .reset_on_wait_frontend_message_on_pause_callback();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v8::isolate::V8Isolate;
+
+    use super::{ClientMessage, DebuggerSession};
+    use std::sync::{Arc, Mutex};
+
+    /*
+    With vscode we crash, with chromium inspector we don't.
+
+    Chromium inspector:
+
+    32029:M 26 May 2023 10:56:37.928 . <redisgears_2> 'v8_rs::v8::inspector::server' /home/fx/workspace/v8-rs/src/v8/inspector/server.rs:281: [OnWait] Read the message: "{\"id\":20,\"method\":\"Debugger.setBreakpointByUrl\",\"params\":{\"lineNumber\":2,\"scriptHash\":\"e18847f3eb3ba96b6de3f10a3370067120fe0f5dc162f58b08e39df7e5f5308f\",\"columnNumber\":68,\"condition\":\"\"}}"
+
+    VSCODE:
+    */
+    #[test]
+    fn can_set_breakpoint() {
+        // Initialise the V8 engine:
+        crate::test_utils::initialize();
+
+        // Create a new isolate:
+        let isolate = V8Isolate::new();
+
+        // Enter the isolate created:
+        let i_scope = isolate.enter();
+
+        // Create the code string object:
+        let code_str = i_scope.new_string("1+1");
+
+        // Create a JS execution context for code invocation:""
+        let ctx = i_scope.new_context(None);
+
+        // Enter the created execution context:
+        let ctx_scope = ctx.enter(&i_scope);
+
+        // Create an inspector.
+        let mut inspector = ctx_scope.new_inspector();
+
+        let stage_1 = Arc::new(Mutex::new(()));
+
+        let lock_1 = stage_1.lock().unwrap();
+
+        // The remote debugging server port for the [WebSocketServer].
+        const PORT_V4: u16 = 9005;
+        // The remote debugging server ip address for the [WebSocketServer].
+        const IP_V4: std::net::Ipv4Addr = std::net::Ipv4Addr::LOCALHOST;
+        // The full remote debugging server host name for the [WebSocketServer].
+        const LOCAL_HOST: std::net::SocketAddrV4 = std::net::SocketAddrV4::new(IP_V4, PORT_V4);
+
+        let address = LOCAL_HOST.to_string();
+        let address = &address;
+
+        let fake_client = {
+            use std::net::TcpStream;
+            use tungstenite::protocol::{Message, WebSocket};
+            use tungstenite::stream::MaybeTlsStream;
+            let address = address.clone();
+
+            let stage_1 = stage_1.clone();
+            #[derive(Copy, Clone, Default, Debug)]
+            struct Client {
+                last_message_id: u64,
+            }
+
+            impl Client {
+                fn send_message(
+                    &mut self,
+                    ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
+                    message: ClientMessage,
+                ) {
+                    let message = Message::Text(serde_json::to_string(&message).unwrap());
+                    ws.write_message(message)
+                        .expect("Couldn't send the message");
+                    self.last_message_id += 1;
+                }
+
+                fn send_ready(&mut self, ws: &mut WebSocket<MaybeTlsStream<TcpStream>>) {
+                    let message = ClientMessage::new_client_ready(self.last_message_id);
+                    self.send_message(ws, message)
+                }
+
+                fn send_breakpoint(
+                    &mut self,
+                    ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
+                    column: u64,
+                    line: u64,
+                    url: &str,
+                ) {
+                    let message =
+                        ClientMessage::new_breakpoint(self.last_message_id, column, line, url);
+                    self.send_message(ws, message)
+                }
+            }
+
+            std::thread::spawn(move || {
+                let mut ws: WebSocket<MaybeTlsStream<TcpStream>>;
+                loop {
+                    match tungstenite::connect(format!("ws://{address}")) {
+                        Ok(s) => {
+                            ws = s.0;
+                            break;
+                        }
+                        _ => continue,
+                    }
+                }
+                let mut client = Client::default();
+                client.send_ready(&mut ws);
+                let _ = ws.read_message();
+                client.send_breakpoint(&mut ws, 0, 0, "
+                file:///home/fx/workspace/RedisGears/redisgears_core/src/lib.rs($|?)|/home/fx/workspace/RedisGears/redisgears_core/src/lib.rs($|?)");
+                drop(stage_1.lock().expect("Couldn't lock the stage 1"));
+                ws.close(None).expect("Couldn't close the WebSocket");
+            })
+        };
+        // Create the debugging server on the default host.
+        let debugger_session = DebuggerSession::new(&mut inspector, address).unwrap();
+        // At this point, the server is running and has accepted a remote
+        // client. Once the client connects, the debugger pauses on the very
+        // first (next) instruction, so we can safely attempt to run the
+        // script, as it won't actually run but will wait for remote client
+        // to act.
+        // Compile the code:
+        let script = ctx_scope.compile(&code_str).unwrap();
+        // Allow the fake client to stop (for this test not to hang).
+        drop(lock_1);
+        // Run the compiled code:
+        let res = script.run(&ctx_scope).unwrap();
+        // To let the remote debugger operate, we need to be able to send
+        // and receive data to and from it. This is achieved by starting the
+        // main loop of the debugger session:
+        // debugger_session.process_messages().expect("Debugger error");
+        debugger_session
+            .read_and_process_next_message()
+            .expect("Debugger error");
+        fake_client
+            .join()
+            .expect("Couldn't join the fake client thread.");
+        // Get the result:
+        let res_utf8 = res.to_utf8().unwrap();
+        assert_eq!(res_utf8.as_str(), "2");
+    }
+}

--- a/src/v8/isolate.rs
+++ b/src/v8/isolate.rs
@@ -22,6 +22,7 @@ use std::os::raw::{c_char, c_int};
 /// An isolate rust wrapper object.
 /// The isolate will not be automatically freed.
 /// In order to free an isolate, one must call [`V8Isolate::free_isolate`].
+#[derive(Debug)]
 pub struct V8Isolate {
     pub(crate) inner_isolate: *mut v8_isolate,
     pub(crate) no_release: bool,

--- a/src/v8/isolate_scope.rs
+++ b/src/v8/isolate_scope.rs
@@ -31,6 +31,7 @@ use crate::v8::v8_value::V8LocalValue;
 
 use std::os::raw::{c_char, c_void};
 
+#[derive(Debug)]
 pub struct V8IsolateScope<'isolate> {
     pub(crate) isolate: &'isolate V8Isolate,
     inner_handlers_scope: *mut v8_handlers_scope,
@@ -110,17 +111,7 @@ impl<'isolate> V8IsolateScope<'isolate> {
         &'isolate_scope self,
         s: &str,
     ) -> V8LocalString<'isolate_scope, 'isolate> {
-        let inner_string = unsafe {
-            v8_NewString(
-                self.isolate.inner_isolate,
-                s.as_ptr().cast::<c_char>(),
-                s.len(),
-            )
-        };
-        V8LocalString {
-            inner_string,
-            isolate_scope: self,
-        }
+        V8LocalString::new(self, s)
     }
 
     /// Create a new string object.

--- a/src/v8/mod.rs
+++ b/src/v8/mod.rs
@@ -9,6 +9,7 @@ use crate::v8_c_raw::bindings::{v8_Dispose, v8_Initialize, v8_Version};
 use std::ffi::CStr;
 use std::ptr;
 
+pub mod inspector;
 pub mod isolate;
 pub mod isolate_scope;
 pub mod try_catch;

--- a/src/v8/v8_context_scope.rs
+++ b/src/v8/v8_context_scope.rs
@@ -4,12 +4,12 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::v8_c_raw::bindings::v8_SetPrivateDataOnCtxRef;
 use crate::v8_c_raw::bindings::{
     v8_Compile, v8_CompileAsModule, v8_ContextRefGetGlobals, v8_ExitContextRef, v8_FreeContextRef,
     v8_GetPrivateDataFromCtxRef, v8_JsonStringify, v8_NewNativeFunction,
     v8_NewObjectFromJsonString, v8_NewResolver, v8_ResetPrivateDataOnCtxRef, v8_context_ref,
 };
+use crate::v8_c_raw::bindings::{v8_SetPrivateDataOnCtxRef, v8_isolate};
 use crate::{RawIndex, UserIndex};
 
 use std::marker::PhantomData;
@@ -26,6 +26,9 @@ use crate::v8::v8_resolver::V8LocalResolver;
 use crate::v8::v8_script::V8LocalScript;
 use crate::v8::v8_string::V8LocalString;
 use crate::v8::v8_value::V8LocalValue;
+
+use super::inspector::Inspector;
+use super::isolate::V8Isolate;
 
 /// An RAII data guard which resets the private data slot after going
 /// out of scope.
@@ -61,6 +64,26 @@ impl<'context_scope, 'data, 'isolate_scope, 'isolate, T: 'data> Drop
     }
 }
 
+/// A context scope as in the "Execution Context" scope. The main
+/// difference from the [V8IsolateScope] is that an `Isolate` is a
+/// lifetime boundary for some V8 Engine state we want to hold, and the
+/// [V8ContextScope] is the execution state of this state. An "isolate"
+/// is more like a storage of data and the code, and the
+/// [V8ContextScope] is the execution state for these data and code.
+///
+/// The [V8ContextScope] is more temporary, and so has more narrow
+/// lifetime, than an isolate (and so [V8IsolateScope]).
+///
+/// All the "local" values, such as, for example, [V8LocalString], are
+/// local to the isolate they were created in, and so to the
+/// [V8IsolateScope]. Such objects can't outlive the parent (their)
+/// isolate and so are always tied to the lifetime of those. To untie
+/// the connection between an object and its isolate, and to make such
+/// an object persistent and not temporary, as in "not tied to the
+/// parent isolate lifetime", it is possible to convert those to some
+/// abstract and serialised persisted values, such as
+/// [crate::v8::v8_value::V8PersistValue].
+#[derive(Debug)]
 pub struct V8ContextScope<'isolate_scope, 'isolate> {
     pub(crate) inner_ctx_ref: *mut v8_context_ref,
     pub(crate) exit_on_drop: bool,
@@ -70,13 +93,18 @@ pub struct V8ContextScope<'isolate_scope, 'isolate> {
 impl<'isolate_scope, 'isolate> V8ContextScope<'isolate_scope, 'isolate> {
     /// Compile the given code into a script object.
     #[must_use]
-    pub fn compile(&self, s: &V8LocalString) -> Option<V8LocalScript<'isolate_scope, 'isolate>> {
-        let inner_script = unsafe { v8_Compile(self.inner_ctx_ref, s.inner_string) };
+    pub fn compile(
+        &self,
+        code: &V8LocalString<'isolate_scope, 'isolate>,
+    ) -> Option<V8LocalScript<'isolate_scope, 'isolate>> {
+        let inner_script = unsafe { v8_Compile(self.inner_ctx_ref, code.inner_string) };
         if inner_script.is_null() {
             None
         } else {
+            let code = code.to_owned();
             Some(V8LocalScript {
                 inner_script,
+                code: code.into(),
                 isolate_scope: self.isolate_scope,
             })
         }
@@ -185,6 +213,13 @@ impl<'isolate_scope, 'isolate> V8ContextScope<'isolate_scope, 'isolate> {
         self.reset_private_data_raw(index)
     }
 
+    /// Creates a new inspector for this context scope.
+    pub fn new_inspector<'context_scope>(
+        &'context_scope self,
+    ) -> Inspector<'context_scope, 'isolate_scope, 'isolate> {
+        Inspector::new_without_callbacks(self)
+    }
+
     /// Create a new resolver object
     #[must_use]
     pub fn new_resolver(&self) -> V8LocalResolver<'isolate_scope, 'isolate> {
@@ -248,6 +283,24 @@ impl<'isolate_scope, 'isolate> V8ContextScope<'isolate_scope, 'isolate> {
             inner_func,
             isolate_scope: self.isolate_scope,
         }
+    }
+
+    fn get_isolate_ptr_mut(&self) -> *mut v8_isolate {
+        self.isolate_scope.isolate.inner_isolate
+    }
+}
+
+impl<'isolate_scope, 'isolate> AsRef<V8Isolate> for V8ContextScope<'isolate_scope, 'isolate> {
+    fn as_ref(&self) -> &V8Isolate {
+        self.isolate_scope.isolate
+    }
+}
+
+impl<'isolate_scope, 'isolate> AsRef<V8IsolateScope<'isolate>>
+    for V8ContextScope<'isolate_scope, 'isolate>
+{
+    fn as_ref(&self) -> &V8IsolateScope<'isolate> {
+        self.isolate_scope
     }
 }
 

--- a/src/v8/v8_script.rs
+++ b/src/v8/v8_script.rs
@@ -4,28 +4,69 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+use std::borrow::Borrow;
+
 use crate::v8_c_raw::bindings::{
-    v8_FreePersistedScript, v8_FreeScript, v8_PersistedScriptToLocal, v8_Run, v8_ScriptPersist,
-    v8_local_script, v8_persisted_script,
+    v8_FreePersistedScript, v8_FreePersistedValue, v8_FreeScript, v8_PersistedScriptToLocal,
+    v8_Run, v8_ScriptPersist, v8_local_script, v8_local_string, v8_persisted_script,
 };
 
 use crate::v8::isolate_scope::V8IsolateScope;
 use crate::v8::v8_context_scope::V8ContextScope;
 use crate::v8::v8_value::V8LocalValue;
 
+use super::v8_string::V8LocalString;
+use super::v8_value::V8PersistValue;
+
 /// JS script object
 pub struct V8LocalScript<'isolate_scope, 'isolate> {
     pub(crate) inner_script: *mut v8_local_script,
+    pub(crate) code: ScriptCode<'isolate_scope, 'isolate>,
     pub(crate) isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
 }
 
+/// A persisted script is a JavaScript-compiled code, which isn't tied
+/// to the isolate it was compiled for. Hence it doesn't have any
+/// lifetime boundaries and can live on its own, and converted into a
+/// [V8LocalScript] later when it is required.
+#[derive(Debug, Clone)]
 pub struct V8PersistedScript {
     pub(crate) inner_persisted_script: *mut v8_persisted_script,
+    /// The [ScriptCode] stored as a persisted value.
+    pub(crate) code: String,
+}
+
+/// The JavaScript code that can be compiled into a [V8LocalScript].
+#[repr(transparent)]
+#[derive(Debug, Clone)]
+pub struct ScriptCode<'isolate_scope, 'isolate>(V8LocalString<'isolate_scope, 'isolate>);
+impl<'isolate_scope, 'isolate> ScriptCode<'isolate_scope, 'isolate> {
+    /// Creates a new [ScriptCode] object for the isolate used by the
+    /// passed [V8ContextScope].
+    pub fn new<T: AsRef<str>, I: Borrow<V8IsolateScope<'isolate>>>(
+        code_string: T,
+        isolate: &'isolate_scope I,
+    ) -> Self {
+        let isolate_scope: &V8IsolateScope = isolate.borrow();
+        Self(isolate_scope.new_string(code_string.as_ref()))
+    }
+
+    /// Compiles the code into a script.
+    pub fn compile(&self, ctx: &V8ContextScope<'isolate_scope, 'isolate>) -> Option<V8LocalScript> {
+        ctx.compile(&self.0)
+    }
+}
+
+impl<'isolate_scope, 'isolate> From<V8LocalString<'isolate_scope, 'isolate>>
+    for ScriptCode<'isolate_scope, 'isolate>
+{
+    fn from(value: V8LocalString<'isolate_scope, 'isolate>) -> Self {
+        Self(value)
+    }
 }
 
 impl<'isolate_scope, 'isolate> V8LocalScript<'isolate_scope, 'isolate> {
-    /// Run the script
-    #[must_use]
+    /// Run the script.
     pub fn run(&self, ctx: &V8ContextScope) -> Option<V8LocalValue<'isolate_scope, 'isolate>> {
         let inner_val = unsafe { v8_Run(ctx.inner_ctx_ref, self.inner_script) };
         if inner_val.is_null() {
@@ -38,13 +79,35 @@ impl<'isolate_scope, 'isolate> V8LocalScript<'isolate_scope, 'isolate> {
         }
     }
 
+    /// Recompiles the script mutating the object (in-place).
+    pub fn recompile(&mut self, ctx: &V8ContextScope<'isolate_scope, 'isolate>) -> bool {
+        if let Some(script) = self.code.compile(ctx) {
+            // unsafe { v8_FreeScript(self.inner_script) }
+            self.inner_script = script.inner_script;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Persists the script by making it not tied to the isolate it was
+    /// created for, allowing it to outlive it and not be bound to any
+    /// lifetime.
     pub fn persist(&self) -> V8PersistedScript {
         let inner_persisted_script = unsafe {
             v8_ScriptPersist(self.isolate_scope.isolate.inner_isolate, self.inner_script)
         };
+        let code = String::from(&self.code.0);
         V8PersistedScript {
             inner_persisted_script,
+            code,
         }
+    }
+}
+
+impl<'isolate_scope, 'isolate> From<V8LocalScript<'isolate_scope, 'isolate>> for V8PersistedScript {
+    fn from(value: V8LocalScript<'isolate_scope, 'isolate>) -> Self {
+        value.persist()
     }
 }
 
@@ -59,10 +122,40 @@ impl V8PersistedScript {
                 self.inner_persisted_script,
             )
         };
+        let code = ScriptCode::new(&self.code, isolate_scope);
         V8LocalScript {
             inner_script,
+            code,
             isolate_scope,
         }
+    }
+
+    /// Returns the code of this script.
+    pub fn get_script_code<'isolate_scope, 'isolate>(
+        &self,
+        isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
+    ) -> ScriptCode<'isolate_scope, 'isolate> {
+        ScriptCode::new(&self.code, isolate_scope)
+    }
+
+    /// Recompiles the script in-place.
+    pub fn recompile<'isolate_scope, 'isolate>(
+        &mut self,
+        ctx: &V8ContextScope<'isolate_scope, 'isolate>,
+    ) -> bool {
+        let code = self.get_script_code(ctx.isolate_scope);
+        let ret = if let Some(new_script) = code.compile(ctx) {
+            let persisted_script = new_script.persist();
+            unsafe {
+                v8_FreePersistedScript(self.inner_persisted_script);
+            }
+            self.inner_persisted_script = persisted_script.inner_persisted_script;
+            std::mem::forget(persisted_script);
+            true
+        } else {
+            false
+        };
+        ret
     }
 }
 
@@ -77,6 +170,8 @@ unsafe impl Send for V8PersistedScript {}
 
 impl Drop for V8PersistedScript {
     fn drop(&mut self) {
-        unsafe { v8_FreePersistedScript(self.inner_persisted_script) }
+        unsafe {
+            v8_FreePersistedScript(self.inner_persisted_script);
+        }
     }
 }

--- a/src/v8/v8_string.rs
+++ b/src/v8/v8_string.rs
@@ -18,7 +18,42 @@ pub struct V8LocalString<'isolate_scope, 'isolate> {
     pub(crate) isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
 }
 
+impl<'isolate_scope, 'isolate> std::fmt::Debug for V8LocalString<'isolate_scope, 'isolate> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string_value = String::from(self.to_owned());
+        #[allow(dead_code)]
+        #[derive(Debug)]
+        struct V8StringDebugPrinter {
+            address: *mut v8_local_string,
+            value: String,
+        }
+        let inner_string = V8StringDebugPrinter {
+            address: self.inner_string,
+            value: string_value,
+        };
+        f.debug_struct("V8LocalString")
+            .field("inner_string", &inner_string)
+            .field("isolate_scope", self.isolate_scope)
+            .finish()
+    }
+}
+
 impl<'isolate_scope, 'isolate> V8LocalString<'isolate_scope, 'isolate> {
+    /// Creates a new string within the provided isolate.
+    pub fn new(isolate_scope: &'isolate_scope V8IsolateScope<'isolate>, s: &str) -> Self {
+        let inner_string = unsafe {
+            crate::v8_c_raw::bindings::v8_NewString(
+                isolate_scope.isolate.inner_isolate,
+                s.as_ptr().cast(),
+                s.len(),
+            )
+        };
+        Self {
+            inner_string,
+            isolate_scope,
+        }
+    }
+
     /// Convert the string object into a generic JS object.
     #[must_use]
     pub fn to_value(&self) -> V8LocalValue<'isolate_scope, 'isolate> {
@@ -29,7 +64,7 @@ impl<'isolate_scope, 'isolate> V8LocalString<'isolate_scope, 'isolate> {
         }
     }
 
-    /// Same as writing 'new String(...)'.
+    /// Same as writing `new String(...)` in JavaScript.
     #[must_use]
     pub fn to_string_object(&self) -> V8LocalObject<'isolate_scope, 'isolate> {
         let inner_obj = unsafe {
@@ -39,6 +74,44 @@ impl<'isolate_scope, 'isolate> V8LocalString<'isolate_scope, 'isolate> {
             inner_obj,
             isolate_scope: self.isolate_scope,
         }
+    }
+}
+
+extern "C" fn convert_c_string_to_rust(
+    string: *mut ::std::os::raw::c_void,
+    data: *const ::std::os::raw::c_char,
+    length: usize,
+) {
+    let string: *mut String = string as _;
+    let data = data as *const u8;
+    let bytes = unsafe { std::slice::from_raw_parts(data, length) };
+    unsafe { string.replace(std::str::from_utf8(bytes).unwrap().to_owned()) };
+}
+
+impl<'isolate_scope, 'isolate> From<V8LocalString<'isolate_scope, 'isolate>> for String {
+    fn from(value: V8LocalString<'isolate_scope, 'isolate>) -> Self {
+        String::from(&value)
+    }
+}
+
+impl<'isolate_scope, 'isolate> From<&V8LocalString<'isolate_scope, 'isolate>> for String {
+    fn from(value: &V8LocalString<'isolate_scope, 'isolate>) -> Self {
+        let mut string = String::default();
+        let string_ptr = &mut string as *mut String as _;
+        unsafe {
+            crate::v8_c_raw::bindings::get_v8_string_value_with_callback(
+                value.inner_string,
+                Some(convert_c_string_to_rust),
+                string_ptr,
+            )
+        };
+        string
+    }
+}
+
+impl<'isolate_scope, 'isolate> Clone for V8LocalString<'isolate_scope, 'isolate> {
+    fn clone(&self) -> Self {
+        Self::new(self.isolate_scope, &String::from(self))
     }
 }
 

--- a/src/v8/v8_value.rs
+++ b/src/v8/v8_value.rs
@@ -47,6 +47,7 @@ pub struct V8CtxValue<'isolate_scope, 'isolate, 'value, 'ctx_scope> {
 }
 
 /// JS generic persisted value
+#[derive(Debug)]
 pub struct V8PersistValue {
     pub(crate) inner_val: *mut v8_persisted_value,
     forget: bool,

--- a/v8-rs-derive/Cargo.toml
+++ b/v8-rs-derive/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version="1.0", features = ["full"]}
-quote = "1.0"
+syn = { version = "2", features = ["full"]}
+quote = "1"
 v8_rs = { path = "../", optional = true }
 
 [features]

--- a/v8_c_api/src/.clangd
+++ b/v8_c_api/src/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    Add: -I./v8include/

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -9,101 +9,109 @@
 
 #include <stddef.h>
 
-/* Allocator definition
+/** Allocator definition
  * Note: only structs memory will be allocated using the allocator,
  *       v8 memory will be allocate and manage by b8. */
-typedef struct v8_alloctor {
+typedef struct v8_allocator {
 	void* (*v8_Alloc)(size_t bytes);
 	void* (*v8_Realloc)(void *ptr, size_t bytes);
 	void  (*v8_Free)(void *ptr);
 	void* (*v8_Calloc)(size_t nmemb, size_t size);
 	char* (*v8_Strdup)(const char *str);
-}v8_alloctor;
+} v8_allocator;
 
-/* Opaque struct representing a v8 interpreter.
+/**
+ * An opaque struct representing a v8 inspector.
+ */
+typedef struct v8_inspector_c_wrapper v8_inspector_c_wrapper;
+
+/** An opaque struct representing a v8 platform. */
+typedef struct v8_platform v8_platform;
+
+/** Opaque struct representing a v8 interpreter.
  * There is no limit to the amount of isolates that can be
  * created in a single processes. */
 typedef struct v8_isolate v8_isolate;
 
-/* Represent a scope to run JS code inside the isolate. */
+/** Represent a scope to run JS code inside the isolate. */
 typedef struct v8_isolate_scope v8_isolate_scope;
 
-/* An isolate JS environment to run JS code.
+/** An isolate JS environment to run JS code.
  * There is no limit to the amount of contexts that can be
  * create in a single isolate. Each context has its own globals
  * separate from other contexts. It is only possible to run a single
  * contexts in a given time (in each isolate) */
 typedef struct v8_context v8_context;
 
-/* Represent a scope to run JS code inside the context. */
+/** Represent a scope to run JS code inside the context. */
 typedef struct v8_context_ref v8_context_ref;
 
-/* Try catch scope, any error that will be raise during JS execution
+/** Try catch scope, any error that will be raise during JS execution
  * will be catch by this object. */
 typedef struct v8_trycatch v8_trycatch;
 
-/* Responsible for all local handlers. When freed, all the locals
+/** Responsible for all local handlers. When freed, all the locals
  * handlers that were manager by the handlers score will be freed. */
 typedef struct v8_handlers_scope v8_handlers_scope;
 
-/* JS String object */
+/** JS String object */
 typedef struct v8_local_string v8_local_string;
 
-/* JS native function template */
+/** JS native function template */
 typedef struct v8_local_native_function_template v8_local_native_function_template;
 
-/* JS native function */
+/** JS native function */
 typedef struct v8_local_native_function v8_local_native_function;
 
-/* JS native object template */
+/** JS native object template */
 typedef struct v8_local_object_template v8_local_object_template;
 
-/* JS native object */
+/** JS native object */
 typedef struct v8_local_object v8_local_object;
 
 typedef struct v8_local_external_data v8_local_external_data;
 
-/* JS native set */
+/** JS native set */
 typedef struct v8_local_set v8_local_set;
 
-/* JS native array*/
+/** JS native array*/
 typedef struct v8_local_array v8_local_array;
 
-/* JS native array buffer*/
+/** JS native array buffer*/
 typedef struct v8_local_array_buff v8_local_array_buff;
 
-/* JS script object */
+/** JS script object */
 typedef struct v8_local_script v8_local_script;
 
 typedef struct v8_persisted_script v8_persisted_script;
 
 typedef struct v8_persisted_object_template v8_persisted_object_template;
 
-/* JS module object */
+/** JS module object */
 typedef struct v8_local_module v8_local_module;
 
-/* JS persisted module object */
+/** JS persisted module object */
 typedef struct v8_persisted_module v8_persisted_module;
 
-/* JS generic value */
+/** JS generic value */
 typedef struct v8_local_value v8_local_value;
 
-/* JS promise object */
+/** JS promise object */
 typedef struct v8_local_promise v8_local_promise;
 
-/* JS promise resolver object */
+/** JS promise resolver object */
 typedef struct v8_local_resolver v8_local_resolver;
 
-/* Represent a native function arguments */
+/** Represent a native function arguments */
 typedef struct v8_local_value_arr v8_local_value_arr;
 
-/* JS utf8 object */
+/** JS utf8 object */
 typedef struct v8_utf8_value v8_utf8_value;
 
-/* JS persisted object, can outlive the handlers score. */
+/** JS persisted object, can outlive the handlers score. */
 typedef struct v8_persisted_value v8_persisted_value;
 
-/* JS persisted object, can outlive the handlers score. */
+/** JS persisted object, can outlive the handlers score. */
 typedef struct v8_unlocker v8_unlocker;
 
 typedef void (*v8_InterruptCallback)(v8_isolate *isolate, void* data);
@@ -113,14 +121,88 @@ typedef void (*v8_InterruptCallback)(v8_isolate *isolate, void* data);
  * Returns and int of value 1 on successfull initialisation, 0
  * otherwise.
  */
-int v8_Initialize(v8_alloctor *allocator, int thread_pool_size);
+int v8_Initialize(v8_allocator *allocator, int thread_pool_size);
+/** Creates a new platform with the thread pool size provided. */
+v8_platform* v8_NewPlatform(const int thread_pool_size);
+/** Initialises a created platform. */
+void v8_InitializePlatform(v8_platform *platform);
 
+typedef void (*v8_InspectorOnResponseCallback)(const char *string, void *userdata);
+typedef int (*v8_InspectorOnWaitFrontendMessageOnPause)(v8_inspector_c_wrapper *inspector,  void *userdata);
+
+/** Creates a debugging inspector for the global platform and the given
+context. The callbacks are optional. */
+v8_inspector_c_wrapper* v8_InspectorCreate(
+	v8_context_ref *context,
+	v8_InspectorOnResponseCallback onResponse,
+	void *onResponseUserData,
+	v8_InspectorOnWaitFrontendMessageOnPause onWaitFrontendMessageOnPause,
+	void *onWaitUserData
+);
+
+/** Deletes (invokes the destructor and deallocates) an inspector
+object. */
+void v8_FreeInspector(v8_inspector_c_wrapper *inspector);
+/** Dispatches an inspector protocol message to the inspector passed. */
+void v8_InspectorDispatchProtocolMessage(v8_inspector_c_wrapper *inspector, const char *message_json);
+/** Schedules a pause (sets a breakpoint) on the next statement, with
+the reason message provided. */
+void v8_InspectorSchedulePauseOnNextStatement(v8_inspector_c_wrapper *inspector, const char *reason);
+/** The callback which is invoked when the V8 Inspector requires more
+ * data from the front-end (the client) and, therefore, this callback
+ * must attempt to read more data and dispatch it to the inspector.
+ *
+ * The callback should return `1` when it is possible to operate (read,
+ * write, send, receive messages) and `0` when not, to indicate the
+ * impossibility of the further action, in which case, the inspector
+ * will stop.
+ */
+void v8_InspectorWaitFrontendMessageOnPause(v8_inspector_c_wrapper *inspector);
+
+/** Sets the "onResponse" callback: a function to be invoked whenever
+the inspector provided needs to reply to the client. */
+void v8_InspectorSetOnResponseCallback(
+	v8_inspector_c_wrapper *inspector,
+	v8_InspectorOnResponseCallback onResponse,
+	void *onResponseUserData
+);
+
+/** Sets the "onWaitFrontendMessageOnPause" callback. */
+void v8_InspectorSetOnWaitFrontendMessageOnPauseCallback(
+	v8_inspector_c_wrapper *inspector,
+	v8_InspectorOnWaitFrontendMessageOnPause onWaitFrontendMessageOnPause,
+	void *onWaitUserData
+);
+
+/** Sets the V8Context for the inspector. */
+void v8_InspectorSetContext(
+	v8_inspector_c_wrapper *inspector,
+	v8_context_ref *context
+);
+
+typedef void (*v8_StringToUtf8StringCallback)(
+	void *userdata,
+	const char *data,
+	const size_t length
+);
+
+/** Allows to get the string bytes in UTF-8 encoding. The C++ side will
+invoke the callback function with userdata and with the string bytes
+and string length
+*/
+void get_v8_string_value_with_callback(
+	v8_local_string *v8_string,
+	v8_StringToUtf8StringCallback callback,
+	void *userdata
+);
+
+/** Returns the version of V8 as an ASCII string. */
 const char* v8_Version();
 
-/* Dispose v8 initialization */
+/** Dispose v8 initialization */
 void v8_Dispose();
 
-/* Create a new v8 isolate. An isolate is a v8 interpreter that responsible to run JS code.
+/** Creates a new v8 isolate. An isolate is a v8 interpreter that responsible to run JS code.
  * Impeder may create as many isolates as wishes.
  * initial_heap_size_in_bytes - the initial isolate heap size
  * maximum_heap_size_in_bytes - maximum isolate heap size. when this value reached,
@@ -128,103 +210,103 @@ void v8_Dispose();
  * will abort the processes with OOM error. */
 v8_isolate* v8_NewIsolate(size_t initial_heap_size_in_bytes, size_t maximum_heap_size_in_bytes);
 
-/* Set fatal error handler, this method should write the error to some log file, when return the processes will exit */
+/** Set fatal error handler, this method should write the error to some log file, when return the processes will exit */
 void v8_IsolateSetFatalErrorHandler(v8_isolate* i, void (*fatal_hanlder)(const char* location, const char* message));
 
-/* Set OOM error handler, this method should write the error to some log file, when return the processes will exit */
+/** Set OOM error handler, this method should write the error to some log file, when return the processes will exit */
 void v8_IsolateSetOOMErrorHandler(v8_isolate* i, void (*oom_hanlder)(const char* location, int is_heap_oom));
 
-/* Set near OOM handler, the callback will be called when almost reaching OOM and allow to increase the max memory to avoid OOM error. */
+/** Set near OOM handler, the callback will be called when almost reaching OOM and allow to increase the max memory to avoid OOM error. */
 void v8_IsolateSetNearOOMHandler(v8_isolate* i, size_t (*near_oom_callback)(void* data, size_t current_heap_limit, size_t initial_heap_limit), void *pd, void(*free_pd)(void*));
 
-/* Return the currently used heap size */
+/** Return the currently used heap size */
 size_t v8_IsolateUsedHeapSize(v8_isolate* i);
 
-/* Return the currently total heap size */
+/** Return the currently total heap size */
 size_t v8_IsolateTotalHeapSize(v8_isolate* i);
 
-/* Return the current heap size limit */
+/** Return the current heap size limit */
 size_t v8_IsolateHeapSizeLimit(v8_isolate* i);
 
 void v8_IsolateNotifyMemoryPressure(v8_isolate* i);
 
-/* Return the currently used isolate or NULL if not isolate is in used */
+/** Return the currently used isolate or NULL if not isolate is in used */
 v8_isolate* v8_IsolateGetCurrent();
 
-/* Terminate the current JS code running on the given isolate */
+/** Terminate the current JS code running on the given isolate */
 void v8_TerminateCurrExecution(v8_isolate* i);
 
-/* Cancel the termination triggered by v8_TerminateCurrExecution, after calling this API it is possible to continue using the isolate */
+/** Cancel the termination triggered by v8_TerminateCurrExecution, after calling this API it is possible to continue using the isolate */
 void v8_CancelTerminateExecution(v8_isolate* i);
 
-/* Free the give isolate */
+/** Free the give isolate */
 void v8_FreeIsolate(v8_isolate* isolate);
 
 void v8_RequestInterrupt(v8_isolate* isolate, v8_InterruptCallback callback, void *data);
 
-/* Enter the given isolate. This function should be called before running any JS
+/** Enter the given isolate. This function should be called before running any JS
  * code on the isolate. */
 v8_isolate_scope* v8_IsolateEnter(v8_isolate *v8_isolate);
 
-/* Exit the isolate, after execute this function it is not allowed to run
+/** Exit the isolate, after execute this function it is not allowed to run
  * any more JS on this isolate until `v8_IsolateEnter` is called again. */
 void v8_IsolateExit(v8_isolate_scope *v8_isolate_scope);
 
-/* Raise an exception, the given value will be treated as the exception value. */
+/** Raise an exception, the given value will be treated as the exception value. */
 void v8_IsolateRaiseException(v8_isolate *isolate, v8_local_value *value);
 
-/* Get current run context from the of this isolate */
+/** Get current run context from the of this isolate */
 v8_context_ref* v8_GetCurrentCtxRef(v8_isolate *isolate);
 
 void v8_IdleNotificationDeadline(v8_isolate *isolate, double deadline_in_seconds);
 
-/* Create a new try catch object, any exception that will be raise during the JS execution
+/** Create a new try catch object, any exception that will be raise during the JS execution
  * will be catch by this object. */
 v8_trycatch* v8_NewTryCatch(v8_isolate *isolate);
 
-/* Return the exception that was catch by the try catch object */
+/** Return the exception that was catch by the try catch object */
 v8_local_value* v8_TryCatchGetException(v8_trycatch *trycatch);
 
-/* Returns the trace of the catch exception */
+/** Returns the trace of the catch exception */
 v8_local_value* v8_TryCatchGetTrace(v8_trycatch *trycatch, v8_context_ref* ctx);
 
-/* Return true if the execution was terminated using v8_TerminateCurrExecution */
+/** Return true if the execution was terminated using v8_TerminateCurrExecution */
 int v8_TryCatchHasTerminated(v8_trycatch *trycatch);
 
-/* Free the try catch object */
+/** Free the try catch object */
 void v8_FreeTryCatch(v8_trycatch *trycatch);
 
-/* Create a new handlers scope, the handler scope is responsible to collect all local
+/** Create a new handlers scope, the handler scope is responsible to collect all local
  * handlers that was created while this object is alive. When freed, mark all the local
  * handlers that was collected for GC. */
 v8_handlers_scope* v8_NewHandlersScope(v8_isolate *v8_isolate);
 
-/* Free the given handlers crope */
+/** Free the given handlers crope */
 void v8_FreeHandlersScope(v8_handlers_scope* v8_handlersScope);
 
-/* Create a new JS context, a context is an isolate environment to run JS code.
+/** Create a new JS context, a context is an isolate environment to run JS code.
  * A context has his own globals which are not shared with other contexts.
  * It is only possible to run a single context on a given time (per isolate). */
 v8_context* v8_NewContext(v8_isolate* v8_isolate, v8_local_object_template *globals);
 
-/* Free the given context */
+/** Free the given context */
 void v8_FreeContext(v8_context* ctx);
 
-/* Set a private data on the given context.
+/** Set a private data on the given context.
  * The private data can later be retrieve using `v8_GetPrivateData`. */
 void v8_SetPrivateData(v8_context* ctx, size_t index, void *pd);
 
-/* Resets the data at the specified slot. */
+/** Resets the data at the specified slot. */
 void v8_ResetPrivateData(v8_context* ctx, size_t index);
 
-/* Resets the data at the specified slot sing a reference to v8_context. */
+/** Resets the data at the specified slot sing a reference to v8_context. */
 void v8_ResetPrivateDataOnCtxRef(v8_context_ref* ctx_ref, size_t index);
 
-/* Return the private data that was set using `v8_SetPrivateData` or NULL
+/** Return the private data that was set using `v8_SetPrivateData` or NULL
  * if no data was set on the given slot. */
 void* v8_GetPrivateData(v8_context* ctx, size_t index);
 
-/* Enter the given context, this function must be called befor running any
+/** Enter the given context, this function must be called befor running any
  * JS code on the given context. */
 v8_context_ref* v8_ContextEnter(v8_context *v8_ctx);
 
@@ -232,71 +314,71 @@ v8_isolate* v8_ContextRefGetIsolate(v8_context_ref *v8_ctx_ref);
 
 v8_local_object* v8_ContextRefGetGlobals(v8_context_ref *v8_ctx_ref);
 
-/* Exit the JS context */
+/** Exit the JS context */
 void v8_ExitContextRef(v8_context_ref *v8_ctx_ref);
 
-/* Free the JS context */
+/** Free the JS context */
 void v8_FreeContextRef(v8_context_ref *v8_ctx_ref);
 
-/* Same as `v8_GetPrivateData` but works on `v8_context_ref` */
+/** Same as `v8_GetPrivateData` but works on `v8_context_ref` */
 void* v8_GetPrivateDataFromCtxRef(v8_context_ref* ctx_ref, size_t index);
 
-/* Same as `v8_SetPrivateData` but works on `v8_context_ref` */
+/** Same as `v8_SetPrivateData` but works on `v8_context_ref` */
 void v8_SetPrivateDataOnCtxRef(v8_context_ref* ctx_ref, size_t index, void *pd);
 
-/* Create a new JS string object */
+/** Create a new JS string object */
 v8_local_string* v8_NewString(v8_isolate* v8_isolate, const char *str, size_t len);
 
-/* Convert the JS string to JS generic value */
+/** Convert the JS string to JS generic value */
 v8_local_value* v8_StringToValue(v8_local_string *str);
 
-/* Convert the JS string to JS string object (same as writing 'new String(...)')*/
+/** Convert the JS string to JS string object (same as writing 'new String(...)')*/
 v8_local_object* v8_StringToStringObject(v8_isolate* v8_isolate, v8_local_string *str);
 
-/* Free the given JS string */
+/** Free the given JS string */
 void v8_FreeString(v8_local_string *str);
 
-/* Native function callback definition */
+/** Native function callback definition */
 typedef v8_local_value* (*native_funcion)(v8_local_value_arr *args, size_t len, void *pd);
 
-/* Create a native function callback template */
+/** Create a native function callback template */
 v8_local_native_function_template* v8_NewNativeFunctionTemplate(v8_isolate* i, native_funcion func, void *pd, void(*freePD)(void *pd));
 
-/* Create a native JS function from the given JS native function template */
+/** Create a native JS function from the given JS native function template */
 v8_local_native_function* v8_NativeFunctionTemplateToFunction(v8_context_ref *ctx_ref, v8_local_native_function_template *func);
 
 v8_local_native_function* v8_NewNativeFunction(v8_context_ref *ctx_ref, native_funcion func, void *pd, void(*freePD)(void *pd));
 
-/* Free the given native function template */
+/** Free the given native function template */
 void v8_FreeNativeFunctionTemplate(v8_local_native_function_template *func);
 
-/* Free the given native function */
+/** Free the given native function */
 void v8_FreeNativeFunction(v8_local_native_function *func);
 
-/* Convert the native function into a generic JS value */
+/** Convert the native function into a generic JS value */
 v8_local_value* v8_NativeFunctionToValue(v8_local_native_function *func);
 
-/* Return the i-th index from the native function arguments */
+/** Return the i-th index from the native function arguments */
 v8_local_value* v8_ArgsGet(v8_local_value_arr *args, size_t i);
 
 v8_local_object* v8_ArgsGetSelf(v8_local_value_arr *args);
 
-/* Return current isolate from the native function arguments */
+/** Return current isolate from the native function arguments */
 v8_isolate* v8_GetCurrentIsolate(v8_local_value_arr *args);
 
-/* Create a new JS object template */
+/** Create a new JS object template */
 v8_local_object_template* v8_NewObjectTemplate(v8_isolate* v8_isolate);
 
-/* Free the given JS object template */
+/** Free the given JS object template */
 void v8_FreeObjectTemplate(v8_local_object_template *obj);
 
-/* Set a function template on the given object template at the given key */
+/** Set a function template on the given object template at the given key */
 void v8_ObjectTemplateSetFunction(v8_local_object_template *obj, v8_local_string *name, v8_local_native_function_template *f);
 
-/* Set an object template on the given object template at the given key */
+/** Set an object template on the given object template at the given key */
 void v8_ObjectTemplateSetObject(v8_local_object_template *obj, v8_local_string *name, v8_local_object_template *o);
 
-/* Set a generic JS value on the given object template at the given key */
+/** Set a generic JS value on the given object template at the given key */
 void v8_ObjectTemplateSetValue(v8_local_object_template *obj, v8_local_string *name, v8_local_value *val);
 
 void v8_ObjectTemplateSetInternalFieldCount(v8_local_object_template *obj, size_t count);
@@ -307,10 +389,10 @@ void v8_FreePersistedObjectTemplate(v8_persisted_object_template* obj);
 
 v8_local_object_template* v8_PersistedObjectTemplateToLocal(v8_isolate *i, v8_persisted_object_template* obj);
 
-/* Convert the given object template to a generic JS value */
+/** Convert the given object template to a generic JS value */
 v8_local_object* v8_ObjectTemplateNewInstance(v8_context_ref *ctx_ref, v8_local_object_template *obj);
 
-/* Compile the given code into a script object */
+/** Compile the given code into a script object */
 v8_local_script* v8_Compile(v8_context_ref* v8_ctx_ref, v8_local_string* str);
 
 v8_persisted_script* v8_ScriptPersist(v8_isolate *i, v8_local_script* script);
@@ -321,15 +403,15 @@ void v8_FreePersistedScript(v8_persisted_script* script);
 
 typedef v8_local_module* (*V8_LoadModuleCallback)(v8_context_ref* v8_ctx_ref, v8_local_string* name, int identity_hash);
 
-/* Compile the given code as a module */
+/** Compile the given code as a module */
 v8_local_module* v8_CompileAsModule(v8_context_ref* v8_ctx_ref, v8_local_string* name, v8_local_string* code, int is_module);
 
-/* Initialize the module, return 1 on success and 0 on failure */
+/** Initialize the module, return 1 on success and 0 on failure */
 int v8_InitiateModule(v8_local_module* m, v8_context_ref* v8_ctx_ref, V8_LoadModuleCallback load_module_callback);
 
 int v8_ModuleGetIdentityHash(v8_local_module* m);
 
-/* Evaluate the module code */
+/** Evaluate the module code */
 v8_local_value* v8_EvaluateModule(v8_local_module* m, v8_context_ref* v8_ctx_ref);
 
 v8_persisted_module* v8_ModulePersist(v8_isolate *i, v8_local_module* m);
@@ -338,175 +420,173 @@ v8_local_module* v8_ModuleToLocal(v8_isolate *i, v8_persisted_module* m);
 
 void v8_FreePersistedModule(v8_persisted_module* m);
 
-/* Evaluate the module code */
+/** Evaluate the module code */
 void v8_FreeModule(v8_local_module* m);
 
-/* Free the given script object */
+/** Free the given script object */
 void v8_FreeScript(v8_local_script *script);
 
-/* Run the given script object */
+/** Run the given script object */
 v8_local_value* v8_Run(v8_context_ref* v8_ctx_ref, v8_local_script* script);
 
-/* Return 1 if the given JS value is a function and 0 otherwise */
+/** Return 1 if the given JS value is a function and 0 otherwise */
 int v8_ValueIsFunction(v8_local_value *val);
 
-/* Invoke the given function */
+/** Invoke the given function */
 v8_local_value* v8_FunctionCall(v8_context_ref *v8_ctx_ref, v8_local_value *val, size_t argc, v8_local_value* const* argv);
 
-/* Return 1 if the given JS value is an async function and 0 otherwise */
+/** Return 1 if the given JS value is an async function and 0 otherwise */
 int v8_ValueIsAsyncFunction(v8_local_value *val);
 
-/* Return 1 if the given JS value is a string and 0 otherwise */
+/** Return 1 if the given JS value is a string and 0 otherwise */
 int v8_ValueIsString(v8_local_value *val);
 
-/* Return 1 if the given JS value is a string object */
+/** Return 1 if the given JS value is a string object */
 int v8_ValueIsStringObject(v8_local_value *val);
 
-/* Convert the generic JS value into a JS string */
+/** Convert the generic JS value into a JS string */
 v8_local_string* v8_ValueAsString(v8_local_value *val);
 
 v8_local_value* v8_ValueFromLong(v8_isolate *i, long long val);
 
-/* Return 1 if the given JS value is a big integer and 0 otherwise */
+/** Return 1 if the given JS value is a big integer and 0 otherwise */
 int v8_ValueIsBigInt(v8_local_value *val);
 
 long long v8_GetBigInt(v8_local_value *val);
 
-/* Return 1 if the given JS value is a number and 0 otherwise */
+/** Return 1 if the given JS value is a number and 0 otherwise */
 int v8_ValueIsNumber(v8_local_value *val);
 
 double v8_GetNumber(v8_local_value *val);
 
-/* Return 1 if the given JS value is a number and 0 otherwise */
+/** Return 1 if the given JS value is a number and 0 otherwise */
 int v8_ValueIsBool(v8_local_value *val);
 
 int v8_GetBool(v8_local_value *val);
 
-
 v8_local_value* v8_ValueFromDouble(v8_isolate *i, double val);
 
-/* Return 1 if the given JS value is a promise and 0 otherwise */
+/** Return 1 if the given JS value is a promise and 0 otherwise */
 int v8_ValueIsPromise(v8_local_value *val);
 
-/* Convert the generic JS value into a JS promise */
+/** Convert the generic JS value into a JS promise */
 v8_local_promise* v8_ValueAsPromise(v8_local_value *val);
 
-/* Return 1 if the given JS value is an object and 0 otherwise */
+/** Return 1 if the given JS value is an object and 0 otherwise */
 int v8_ValueIsObject(v8_local_value *val);
 
 int v8_ValueIsExternalData(v8_local_value *val);
 
-/* Return an array contains the enumerable properties names of the given object */
-v8_local_array* v8_ValueGetPropertyNames(v8_context_ref *ctx_ref, v8_local_object *obj);
-
-/* Return an array contains the all properties names of the given object */
+/** Return an array contains the all properties names of the given object */
 v8_local_array* v8_ValueGetOwnPropertyNames(v8_context_ref *ctx_ref, v8_local_object *obj);
 
-/* Deleted the given propery from the object */
+/** Deleted the given propery from the object */
 int v8_DeletePropery(v8_context_ref *ctx_ref, v8_local_object *obj, v8_local_value *key);
+/** Return an array contains the enumerable property names of the given object */
+v8_local_array* v8_ValueGetPropertyNames(v8_context_ref *ctx_ref, v8_local_object *obj);
 
-/* Return 1 if the given JS value is an array and 0 otherwise */
+/** Return 1 if the given JS value is an array and 0 otherwise */
 int v8_ValueIsArray(v8_local_value *val);
 
-/* Return 1 if the given JS value is an array buffer and 0 otherwise */
+/** Return 1 if the given JS value is an array buffer and 0 otherwise */
 int v8_ValueIsArrayBuffer(v8_local_value *val);
 
-/* Create a new JS object */
+/** Create a new JS object */
 v8_local_object* v8_NewObject(v8_isolate *i);
 
 v8_local_external_data* v8_NewExternalData(v8_isolate *i, void *data, void(*free)(void*));
 
 void* v8_ExternalDataGet(v8_local_external_data *ext);
 
-/* create a js object form json string */
+/** create a js object form json string */
 v8_local_value* v8_NewObjectFromJsonString(v8_context_ref *ctx_ref, v8_local_string *str);
 
-/* create a json string representation of a JS value */
+/** create a json string representation of a JS value */
 v8_local_string* v8_JsonStringify(v8_context_ref *ctx_ref, v8_local_value *val);
 
-/* Convert the generic JS value into a JS object */
+/** Convert the generic JS value into a JS object */
 v8_local_object* v8_ValueAsObject(v8_local_value *val);
 
 v8_local_external_data* v8_ValueAsExternalData(v8_local_value *val);
 
-/* Convert the generic JS value into a JS resolver*/
+/** Convert the generic JS value into a JS resolver*/
 v8_local_resolver* v8_ValueAsResolver(v8_local_value *val);
 
-/* Return the value of a given key from the given JS object */
+/** Return the value of a given key from the given JS object */
 v8_local_value* v8_ObjectGet(v8_context_ref *ctx_ref, v8_local_object *obj, v8_local_value *key);
 
-/* Set a value inside the object at a given key */
+/** Set a value inside the object at a given key */
 void v8_ObjectSet(v8_context_ref *ctx_ref, v8_local_object *obj, v8_local_value *key, v8_local_value *val);
 
 void v8_ObjectSetInternalField(v8_local_object *obj, size_t index, v8_local_value *val);
 
 v8_local_value* v8_ObjectGetInternalField(v8_local_object *obj, size_t index);
 
-/* Freeze the object, same as Object.freeze. */
+/** Freeze the object, same as Object.freeze. */
 void v8_ObjectFreeze(v8_context_ref *ctx_ref, v8_local_object *obj);
 
-/* Free the given JS object */
+/** Free the given JS object */
 void v8_FreeObject(v8_local_object *obj);
 
 size_t v8_GetInternalFieldCount(v8_local_object *obj);
 
 void v8_FreeExternalData(v8_local_external_data *ext);
 
-/* Convert the given JS object into JS generic value */
+/** Convert the given JS object into JS generic value */
 v8_local_value* v8_ObjectToValue(v8_local_object *obj);
 
-/* Shellow copy of the given JS value. */
+/** Shallow copy of the given JS value. */
 v8_local_value* v8_ValueToValue(v8_local_value *obj);
 
 v8_local_value* v8_ExternalDataToValue(v8_local_external_data *ext);
 
-/* Create a new set */
+/** Create a new set */
 v8_local_set* v8_NewSet(v8_isolate *i);
 
-/* Add a value to the set */
+/** Add a value to the set */
 void v8_SetAdd(v8_context_ref *ctx_ref, v8_local_set *set, v8_local_value *val);
 
-/* Turn the set into an array for iterations. */
+/** Turn the set into an array for iterations. */
 v8_local_array* v8_SetAsArray(v8_local_set *set);
 
-/* Convert the given JS set into JS generic value */
+/** Convert the given JS set into JS generic value */
 v8_local_value* v8_SetToValue(v8_local_set *set);
 
-/* Convert the generic JS value into a JS set */
+/** Convert the generic JS value into a JS set */
 v8_local_set* v8_ValueAsSet(v8_local_value *val);
 
-/* Return 1 if the given JS value is a set and 0 otherwise */
+/** Return 1 if the given JS value is a set and 0 otherwise */
 int v8_ValueIsSet(v8_local_value *val);
 
-/* Free the given JS set */
+/** Free the given JS set */
 void v8_FreeSet(v8_local_set *set);
 
-/* Create a new boolean */
+/** Create a new boolean */
 v8_local_value* v8_NewBool(v8_isolate *i, int val);
 
-/* Create a new JS null */
+/** Create a new JS null */
 v8_local_value* v8_NewNull(v8_isolate *i);
 
-/* Return 1 if the given JS value is null 0 otherwise */
+/** Return 1 if the given JS value is null 0 otherwise */
 int v8_ValueIsNull(v8_local_value *val);
 
-/* Return 1 if the given JS value is undefined 0 otherwise */
+/** Return 1 if the given JS value is undefined 0 otherwise */
 int v8_ValueIsUndefined(v8_local_value *val);
 
-/* Create a js ArrayBuffer */
+/** Create a js ArrayBuffer */
 v8_local_array_buff* v8_NewArrayBuffer(v8_isolate *i, const char *data, size_t len);
 
 v8_local_value* v8_ArrayBufferToValue(v8_local_array_buff *arr_buffer);
 
-/* Return the underline data of an array buffer */
+/** Return the underline data of an array buffer */
 const void* v8_ArrayBufferGetData(v8_local_array_buff *arr_buffer, size_t *len);
 
-/* Free a js ArrayBuffer */
+/** Free a js ArrayBuffer */
 void v8_FreeArrayBuffer(v8_local_array_buff *arr_buffer);
 
 v8_local_array* v8_NewArray(v8_isolate *i, v8_local_value *const *vals, size_t len);
 
-/* Free the given JS array */
+/** Free the given JS array */
 void v8_FreeArray(v8_local_array *arr);
 
 size_t v8_ArrayLen(v8_local_array *arr);
@@ -515,79 +595,79 @@ v8_local_value* v8_ArrayGet(v8_context_ref *ctx_ref, v8_local_array *arr, size_t
 
 v8_local_value* v8_ArrayToValue(v8_local_array *obj);
 
-/* Convert the generic JS value into a JS array */
+/** Convert the generic JS value into a JS array */
 v8_local_array* v8_ValueAsArray(v8_local_value *val);
 
-/* Convert the generic JS value into a JS array buffer */
+/** Convert the generic JS value into a JS array buffer */
 v8_local_array_buff* v8_ValueAsArrayBuffer(v8_local_value *val);
 
-/* Promise state */
+/** Promise state */
 typedef enum v8_PromiseState{
 	v8_PromiseState_Unknown, v8_PromiseState_Fulfilled, v8_PromiseState_Rejected, v8_PromiseState_Pending
 }v8_PromiseState;
 
-/* Free the given promise object */
+/** Free the given promise object */
 void v8_FreePromise(v8_local_promise* promise);
 
-/* Return the state of the given promise object */
+/** Return the state of the given promise object */
 v8_PromiseState v8_PromiseGetState(v8_local_promise* promise);
 
-/* Return the result of the given promise object
+/** Return the result of the given promise object
  * Only applicable when the promise state is v8_PromiseState_Fulfilled or v8_PromiseState_Rejected*/
 v8_local_value* v8_PromiseGetResult(v8_local_promise* promise);
 
-/* Set the promise fulfilled/rejected callbacks */
+/** Set the promise fulfilled/rejected callbacks */
 void v8_PromiseThen(v8_local_promise* promise, v8_context_ref *ctx_ref, v8_local_native_function *resolve, v8_local_native_function *reject);
 
-/* Convert the given promise object into a generic JS value. */
+/** Convert the given promise object into a generic JS value. */
 v8_local_value* v8_PromiseToValue(v8_local_promise *promise);
 
-/* Create a new resolver object */
+/** Create a new resolver object */
 v8_local_resolver* v8_NewResolver(v8_context_ref *ctx_ref);
 
-/* Free the given resolver object */
+/** Free the given resolver object */
 void v8_FreeResolver(v8_local_resolver *resolver);
 
-/* Return a promise object attached to this resolver */
+/** Return a promise object attached to this resolver */
 v8_local_promise* v8_ResolverGetPromise(v8_local_resolver *resolver);
 
-/* Resolve the resolver object with the given value */
+/** Resolve the resolver object with the given value */
 void v8_ResolverResolve(v8_context_ref *ctx_ref, v8_local_resolver *resolver, v8_local_value *val);
 
-/* Reject the resolver object with the given value */
+/** Reject the resolver object with the given value */
 void v8_ResolverReject(v8_context_ref *ctx_ref, v8_local_resolver *resolver, v8_local_value *val);
 
-/* Convert the given resolver object into a generic JS value */
+/** Convert the given resolver object into a generic JS value */
 v8_local_value* v8_ResolverToValue(v8_local_resolver *resolver);
 
-/* Persist the generic JS value, this function allows to escape the handlers scope and save
+/** Persist the generic JS value, this function allows to escape the handlers scope and save
  * the given object for unlimited time with out worry about GC. */
 v8_persisted_value* v8_PersistValue(v8_isolate *i, v8_local_value *val);
 
-/* Turn the persisted value back to local value */
+/** Turn the persisted value back to local value */
 v8_local_value* v8_PersistedValueToLocal(v8_isolate *i, v8_persisted_value *val);
 
-/* Free the given persisted value */
+/** Free the given persisted value */
 void v8_FreePersistedValue(v8_persisted_value *val);
 
-/* Free the given generic JS value */
+/** Free the given generic JS value */
 void v8_FreeValue(v8_local_value *val);
 
-/* Convert the given generic JS value to utf8.
+/** Convert the given generic JS value to utf8.
  * On failure, returns NULL.*/
 v8_utf8_value* v8_ToUtf8(v8_isolate *isolate, v8_local_value *val);
 
-/* Free the given uft8 object */
+/** Free the given uft8 object */
 void v8_FreeUtf8(v8_utf8_value *val);
 
-/* Return const pointer and length of the utf8 object */
+/** Return const pointer and length of the utf8 object */
 const char* v8_Utf8PtrLen(v8_utf8_value *val, size_t *len);
 
-/* Create an unlocker object that will unlock the v8 lock,
+/** Create an unlocker object that will unlock the v8 lock,
  * to re-aquire the lock the unlocker need to be freed */
 v8_unlocker* v8_NewUnlocker(v8_isolate *i);
 
-/* Free the unlocker and re-aquire the lock */
+/** Free the unlocker and re-aquire the lock */
 void v8_FreeUnlocker(v8_unlocker* unlocker);
 
 #endif /* SRC_V8_C_API_H_ */

--- a/v8_c_api/src/v8include/cppgc/DEPS
+++ b/v8_c_api/src/v8include/cppgc/DEPS
@@ -2,6 +2,7 @@ include_rules = [
   "-include",
   "+v8config.h",
   "+v8-platform.h",
+  "+v8-source-location.h",
   "+cppgc",
   "-src",
   "+libplatform/libplatform.h",

--- a/v8_c_api/src/v8include/cppgc/source-location.h
+++ b/v8_c_api/src/v8include/cppgc/source-location.h
@@ -5,87 +5,11 @@
 #ifndef INCLUDE_CPPGC_SOURCE_LOCATION_H_
 #define INCLUDE_CPPGC_SOURCE_LOCATION_H_
 
-#include <cstddef>
-#include <string>
-
-#include "v8config.h"  // NOLINT(build/include_directory)
-
-#if defined(__has_builtin)
-#define CPPGC_SUPPORTS_SOURCE_LOCATION                                   \
-  (__has_builtin(__builtin_FUNCTION) && __has_builtin(__builtin_FILE) && \
-   __has_builtin(__builtin_LINE))  // NOLINT
-#elif defined(V8_CC_GNU) && __GNUC__ >= 7
-#define CPPGC_SUPPORTS_SOURCE_LOCATION 1
-#elif defined(V8_CC_INTEL) && __ICC >= 1800
-#define CPPGC_SUPPORTS_SOURCE_LOCATION 1
-#else
-#define CPPGC_SUPPORTS_SOURCE_LOCATION 0
-#endif
+#include "v8-source-location.h"
 
 namespace cppgc {
 
-/**
- * Encapsulates source location information. Mimics C++20's
- * `std::source_location`.
- */
-class V8_EXPORT SourceLocation final {
- public:
-  /**
-   * Construct source location information corresponding to the location of the
-   * call site.
-   */
-#if CPPGC_SUPPORTS_SOURCE_LOCATION
-  static constexpr SourceLocation Current(
-      const char* function = __builtin_FUNCTION(),
-      const char* file = __builtin_FILE(), size_t line = __builtin_LINE()) {
-    return SourceLocation(function, file, line);
-  }
-#else
-  static constexpr SourceLocation Current() { return SourceLocation(); }
-#endif  // CPPGC_SUPPORTS_SOURCE_LOCATION
-
-  /**
-   * Constructs unspecified source location information.
-   */
-  constexpr SourceLocation() = default;
-
-  /**
-   * Returns the name of the function associated with the position represented
-   * by this object, if any.
-   *
-   * \returns the function name as cstring.
-   */
-  constexpr const char* Function() const { return function_; }
-
-  /**
-   * Returns the name of the current source file represented by this object.
-   *
-   * \returns the file name as cstring.
-   */
-  constexpr const char* FileName() const { return file_; }
-
-  /**
-   * Returns the line number represented by this object.
-   *
-   * \returns the line number.
-   */
-  constexpr size_t Line() const { return line_; }
-
-  /**
-   * Returns a human-readable string representing this object.
-   *
-   * \returns a human-readable string representing source location information.
-   */
-  std::string ToString() const;
-
- private:
-  constexpr SourceLocation(const char* function, const char* file, size_t line)
-      : function_(function), file_(file), line_(line) {}
-
-  const char* function_ = nullptr;
-  const char* file_ = nullptr;
-  size_t line_ = 0u;
-};
+using SourceLocation = v8::SourceLocation;
 
 }  // namespace cppgc
 

--- a/v8_c_api/src/v8include/js_protocol.pdl
+++ b/v8_c_api/src/v8include/js_protocol.pdl
@@ -580,6 +580,7 @@ domain Debugger
         other
         promiseRejection
         XHR
+        step
       # Object containing break-specific auxiliary properties.
       optional object data
       # Hit breakpoints IDs
@@ -631,7 +632,7 @@ domain Debugger
       Runtime.ExecutionContextId executionContextId
       # Content hash of the script, SHA-256.
       string hash
-      # Embedder-specific auxiliary data.
+      # Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'|'isolated'|'worker', frameId: string}
       optional object executionContextAuxData
       # URL of source map associated with script (if any).
       optional string sourceMapURL
@@ -670,7 +671,7 @@ domain Debugger
       Runtime.ExecutionContextId executionContextId
       # Content hash of the script, SHA-256.
       string hash
-      # Embedder-specific auxiliary data.
+      # Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'|'isolated'|'worker', frameId: string}
       optional object executionContextAuxData
       # True, if this script is generated as a result of the live edit operation.
       experimental optional boolean isLiveEdit
@@ -1283,7 +1284,7 @@ domain Runtime
       # multiple processes, so can be reliably used to identify specific context while backend
       # performs a cross-process navigation.
       experimental string uniqueId
-      # Embedder-specific auxiliary data.
+      # Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'|'isolated'|'worker', frameId: string}
       optional object auxData
 
   # Detailed information about exception (or error) that was thrown during script compilation or

--- a/v8_c_api/src/v8include/v8-callbacks.h
+++ b/v8_c_api/src/v8include/v8-callbacks.h
@@ -323,12 +323,6 @@ using WasmAsyncResolvePromiseCallback = void (*)(
 using WasmLoadSourceMapCallback = Local<String> (*)(Isolate* isolate,
                                                     const char* name);
 
-// --- Callback for checking if WebAssembly Simd is enabled ---
-using WasmSimdEnabledCallback = bool (*)(Local<Context> context);
-
-// --- Callback for checking if WebAssembly exceptions are enabled ---
-using WasmExceptionsEnabledCallback = bool (*)(Local<Context> context);
-
 // --- Callback for checking if WebAssembly GC is enabled ---
 // If the callback returns true, it will also enable Wasm stringrefs.
 using WasmGCEnabledCallback = bool (*)(Local<Context> context);

--- a/v8_c_api/src/v8include/v8-context.h
+++ b/v8_c_api/src/v8include/v8-context.h
@@ -395,7 +395,7 @@ Local<Value> Context::GetEmbedderData(int index) {
 #ifndef V8_ENABLE_CHECKS
   using A = internal::Address;
   using I = internal::Internals;
-  A ctx = *reinterpret_cast<const A*>(this);
+  A ctx = internal::ValueHelper::ValueAsAddress(this);
   A embedder_data =
       I::ReadTaggedPointerField(ctx, I::kNativeContextEmbedderDataOffset);
   int value_offset =
@@ -407,15 +407,9 @@ Local<Value> Context::GetEmbedderData(int index) {
   value = I::DecompressTaggedField(embedder_data, static_cast<uint32_t>(value));
 #endif
 
-#ifdef V8_ENABLE_CONSERVATIVE_STACK_SCANNING
-  return Local<Value>(reinterpret_cast<Value*>(value));
-#else
-  internal::Isolate* isolate = internal::IsolateFromNeverReadOnlySpaceObject(
-      *reinterpret_cast<A*>(this));
-  A* result = HandleScope::CreateHandle(isolate, value);
-  return Local<Value>(reinterpret_cast<Value*>(result));
-#endif
-
+  auto isolate = reinterpret_cast<v8::Isolate*>(
+      internal::IsolateFromNeverReadOnlySpaceObject(ctx));
+  return Local<Value>::New(isolate, value);
 #else
   return SlowGetEmbedderData(index);
 #endif
@@ -442,9 +436,11 @@ void* Context::GetAlignedPointerFromEmbedderData(int index) {
 
 template <class T>
 MaybeLocal<T> Context::GetDataFromSnapshotOnce(size_t index) {
-  T* data = reinterpret_cast<T*>(GetDataFromSnapshotOnce(index));
-  if (data) internal::PerformCastCheck(data);
-  return Local<T>(data);
+  auto slot = GetDataFromSnapshotOnce(index);
+  if (slot) {
+    internal::PerformCastCheck(internal::ValueHelper::SlotAsValue<T>(slot));
+  }
+  return Local<T>::FromSlot(slot);
 }
 
 Context* Context::Cast(v8::Data* data) {

--- a/v8_c_api/src/v8include/v8-embedder-heap.h
+++ b/v8_c_api/src/v8include/v8-embedder-heap.h
@@ -34,6 +34,8 @@ class V8_EXPORT EmbedderRootsHandler {
    * for retaining the object. The embedder may use |WrapperClassId()| to
    * distinguish cases where it wants handles to be treated as roots from not
    * being treated as roots.
+   *
+   * The concrete implementations must be thread-safe.
    */
   virtual bool IsRoot(const v8::TracedReference<v8::Value>& handle) = 0;
 
@@ -45,6 +47,8 @@ class V8_EXPORT EmbedderRootsHandler {
    * Note that the |handle| is different from the handle that the embedder holds
    * for retaining the object. It is up to the embedder to find the original
    * handle via the object or class id.
+   *
+   * The concrete implementations must be thread-safe.
    */
   virtual void ResetRoot(const v8::TracedReference<v8::Value>& handle) = 0;
 };

--- a/v8_c_api/src/v8include/v8-function-callback.h
+++ b/v8_c_api/src/v8include/v8-function-callback.h
@@ -78,7 +78,6 @@ class ReturnValue {
 
   // See FunctionCallbackInfo.
   static constexpr int kIsolateValueIndex = -2;
-  static constexpr int kDefaultValueValueIndex = -1;
 
   internal::Address* value_;
 };
@@ -128,15 +127,16 @@ class FunctionCallbackInfo {
   friend class internal::CustomArguments<FunctionCallbackInfo>;
   friend class debug::ConsoleCallArguments;
   friend class internal::Builtins;
+
   static constexpr int kHolderIndex = 0;
   static constexpr int kIsolateIndex = 1;
-  static constexpr int kReturnValueDefaultValueIndex = 2;
+  static constexpr int kUnusedIndex = 2;
   static constexpr int kReturnValueIndex = 3;
   static constexpr int kDataIndex = 4;
   static constexpr int kNewTargetIndex = 5;
-
   static constexpr int kArgsLength = 6;
-  static constexpr int kArgsLengthWithReceiver = 7;
+
+  static constexpr int kArgsLengthWithReceiver = kArgsLength + 1;
 
   // Codegen constants:
   static constexpr int kSize = 3 * internal::kApiSystemPointerSize;
@@ -147,8 +147,6 @@ class FunctionCallbackInfo {
       kValuesOffset + internal::kApiSystemPointerSize;
 
   static constexpr int kThisValuesIndex = -1;
-  static_assert(ReturnValue<Value>::kDefaultValueValueIndex ==
-                kReturnValueDefaultValueIndex - kReturnValueIndex);
   static_assert(ReturnValue<Value>::kIsolateValueIndex ==
                 kIsolateIndex - kReturnValueIndex);
 
@@ -258,17 +256,17 @@ class PropertyCallbackInfo {
   static constexpr int kShouldThrowOnErrorIndex = 0;
   static constexpr int kHolderIndex = 1;
   static constexpr int kIsolateIndex = 2;
-  static constexpr int kReturnValueDefaultValueIndex = 3;
+  static constexpr int kUnusedIndex = 3;
   static constexpr int kReturnValueIndex = 4;
   static constexpr int kDataIndex = 5;
   static constexpr int kThisIndex = 6;
-
   static constexpr int kArgsLength = 7;
 
   static constexpr int kSize = 1 * internal::kApiSystemPointerSize;
 
   V8_INLINE explicit PropertyCallbackInfo(internal::Address* args)
       : args_(args) {}
+
   internal::Address* args_;
 };
 
@@ -286,7 +284,7 @@ void ReturnValue<T>::Set(const Global<S>& handle) {
   if (V8_UNLIKELY(handle.IsEmpty())) {
     *value_ = GetDefaultValue();
   } else {
-    *value_ = *reinterpret_cast<internal::Address*>(*handle);
+    *value_ = handle.ptr();
   }
 }
 
@@ -297,7 +295,7 @@ void ReturnValue<T>::Set(const BasicTracedReference<S>& handle) {
   if (V8_UNLIKELY(handle.IsEmpty())) {
     *value_ = GetDefaultValue();
   } else {
-    *value_ = *reinterpret_cast<internal::Address*>(handle.val_);
+    *value_ = handle.ptr();
   }
 }
 
@@ -309,7 +307,7 @@ void ReturnValue<T>::Set(const Local<S> handle) {
   if (V8_UNLIKELY(handle.IsEmpty())) {
     *value_ = GetDefaultValue();
   } else {
-    *value_ = internal::ValueHelper::ValueAsAddress(*handle);
+    *value_ = handle.ptr();
   }
 }
 
@@ -378,7 +376,6 @@ void ReturnValue<T>::SetEmptyString() {
 
 template <typename T>
 Isolate* ReturnValue<T>::GetIsolate() const {
-  // Isolate is always the pointer below the default value on the stack.
   return *reinterpret_cast<Isolate**>(&value_[kIsolateValueIndex]);
 }
 
@@ -403,8 +400,8 @@ void ReturnValue<T>::Set(S* whatever) {
 
 template <typename T>
 internal::Address ReturnValue<T>::GetDefaultValue() {
-  // Default value is always the pointer below value_ on the stack.
-  return value_[kDefaultValueValueIndex];
+  using I = internal::Internals;
+  return I::GetRoot(GetIsolate(), I::kTheHoleValueRootIndex);
 }
 
 template <typename T>

--- a/v8_c_api/src/v8include/v8-handle-base.h
+++ b/v8_c_api/src/v8include/v8-handle-base.h
@@ -1,0 +1,190 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef INCLUDE_V8_HANDLE_BASE_H_
+#define INCLUDE_V8_HANDLE_BASE_H_
+
+#include "v8-internal.h"  // NOLINT(build/include_directory)
+
+namespace v8 {
+
+namespace internal {
+
+// Helper functions about values contained in handles.
+// A value is either an indirect pointer or a direct pointer, depending on
+// whether direct local support is enabled.
+class ValueHelper final {
+ public:
+#ifdef V8_ENABLE_DIRECT_LOCAL
+  static constexpr Address kTaggedNullAddress = 1;
+  static constexpr Address kEmpty = kTaggedNullAddress;
+#else
+  static constexpr Address kEmpty = kNullAddress;
+#endif  // V8_ENABLE_DIRECT_LOCAL
+
+  template <typename T>
+  V8_INLINE static bool IsEmpty(T* value) {
+    return reinterpret_cast<Address>(value) == kEmpty;
+  }
+
+  // Returns a handle's "value" for all kinds of abstract handles. For Local,
+  // it is equivalent to `*handle`. The variadic parameters support handle
+  // types with extra type parameters, like `Persistent<T, M>`.
+  template <template <typename T, typename... Ms> typename H, typename T,
+            typename... Ms>
+  V8_INLINE static T* HandleAsValue(const H<T, Ms...>& handle) {
+    return handle.template value<T>();
+  }
+
+#ifdef V8_ENABLE_DIRECT_LOCAL
+
+  template <typename T>
+  V8_INLINE static Address ValueAsAddress(const T* value) {
+    return reinterpret_cast<Address>(value);
+  }
+
+  template <typename T, typename S>
+  V8_INLINE static T* SlotAsValue(S* slot) {
+    return *reinterpret_cast<T**>(slot);
+  }
+
+  template <typename T>
+  V8_INLINE static T* ValueAsSlot(T* const& value) {
+    return reinterpret_cast<T*>(const_cast<T**>(&value));
+  }
+
+#else  // !V8_ENABLE_DIRECT_LOCAL
+
+  template <typename T>
+  V8_INLINE static Address ValueAsAddress(const T* value) {
+    return *reinterpret_cast<const Address*>(value);
+  }
+
+  template <typename T, typename S>
+  V8_INLINE static T* SlotAsValue(S* slot) {
+    return reinterpret_cast<T*>(slot);
+  }
+
+  template <typename T>
+  V8_INLINE static T* ValueAsSlot(T* const& value) {
+    return value;
+  }
+
+#endif  // V8_ENABLE_DIRECT_LOCAL
+};
+
+/**
+ * Helper functions about handles.
+ */
+class HandleHelper final {
+ public:
+  /**
+   * Checks whether two handles are equal.
+   * They are equal iff they are both empty or they are both non-empty and the
+   * objects to which they refer are physically equal.
+   *
+   * If both handles refer to JS objects, this is the same as strict equality.
+   * For primitives, such as numbers or strings, a `false` return value does not
+   * indicate that the values aren't equal in the JavaScript sense.
+   * Use `Value::StrictEquals()` to check primitives for equality.
+   */
+  template <typename T1, typename T2>
+  V8_INLINE static bool EqualHandles(const T1& lhs, const T2& rhs) {
+    if (lhs.IsEmpty()) return rhs.IsEmpty();
+    if (rhs.IsEmpty()) return false;
+    return lhs.ptr() == rhs.ptr();
+  }
+};
+
+}  // namespace internal
+
+/**
+ * A base class for abstract handles containing indirect pointers.
+ * These are useful regardless of whether direct local support is enabled.
+ */
+class IndirectHandleBase {
+ public:
+  // Returns true if the handle is empty.
+  V8_INLINE bool IsEmpty() const { return location_ == nullptr; }
+
+  // Sets the handle to be empty. IsEmpty() will then return true.
+  V8_INLINE void Clear() { location_ = nullptr; }
+
+ protected:
+  friend class internal::ValueHelper;
+  friend class internal::HandleHelper;
+
+  V8_INLINE IndirectHandleBase() = default;
+  V8_INLINE IndirectHandleBase(const IndirectHandleBase& other) = default;
+  V8_INLINE IndirectHandleBase& operator=(const IndirectHandleBase& that) =
+      default;
+
+  V8_INLINE explicit IndirectHandleBase(internal::Address* location)
+      : location_(location) {}
+
+  // Returns the address of the actual heap object (tagged).
+  // This method must be called only if the handle is not empty, otherwise it
+  // will crash.
+  V8_INLINE internal::Address ptr() const { return *location_; }
+
+  // Returns a reference to the slot (indirect pointer).
+  V8_INLINE internal::Address* const& slot() const { return location_; }
+  V8_INLINE internal::Address*& slot() { return location_; }
+
+  // Returns the handler's "value" (direct or indirect pointer, depending on
+  // whether direct local support is enabled).
+  template <typename T>
+  V8_INLINE T* value() const {
+    return internal::ValueHelper::SlotAsValue<T>(slot());
+  }
+
+ private:
+  internal::Address* location_ = nullptr;
+};
+
+#ifdef V8_ENABLE_DIRECT_LOCAL
+
+/**
+ * A base class for abstract handles containing direct pointers.
+ * These are only possible when conservative stack scanning is enabled.
+ */
+class DirectHandleBase {
+ public:
+  // Returns true if the handle is empty.
+  V8_INLINE bool IsEmpty() const {
+    return ptr_ == internal::ValueHelper::kEmpty;
+  }
+
+  // Sets the handle to be empty. IsEmpty() will then return true.
+  V8_INLINE void Clear() { ptr_ = internal::ValueHelper::kEmpty; }
+
+ protected:
+  friend class internal::ValueHelper;
+  friend class internal::HandleHelper;
+
+  V8_INLINE DirectHandleBase() = default;
+  V8_INLINE DirectHandleBase(const DirectHandleBase& other) = default;
+  V8_INLINE DirectHandleBase& operator=(const DirectHandleBase& that) = default;
+
+  V8_INLINE explicit DirectHandleBase(internal::Address ptr) : ptr_(ptr) {}
+
+  // Returns the address of the referenced object.
+  V8_INLINE internal::Address ptr() const { return ptr_; }
+
+  // Returns the handler's "value" (direct pointer, as direct local support
+  // is guaranteed to be enabled here).
+  template <typename T>
+  V8_INLINE T* value() const {
+    return reinterpret_cast<T*>(ptr_);
+  }
+
+ private:
+  internal::Address ptr_ = internal::ValueHelper::kEmpty;
+};
+
+#endif  // V8_ENABLE_DIRECT_LOCAL
+
+}  // namespace v8
+
+#endif  // INCLUDE_V8_HANDLE_BASE_H_

--- a/v8_c_api/src/v8include/v8-internal.h
+++ b/v8_c_api/src/v8include/v8-internal.h
@@ -522,6 +522,8 @@ class Internals {
   static const int kBuiltinTier0TableSize = 7 * kApiSystemPointerSize;
   static const int kLinearAllocationAreaSize = 3 * kApiSystemPointerSize;
   static const int kThreadLocalTopSize = 25 * kApiSystemPointerSize;
+  static const int kHandleScopeDataSize =
+      2 * kApiSystemPointerSize + 2 * kApiInt32Size;
 
   // ExternalPointerTable layout guarantees.
   static const int kExternalPointerTableBufferOffset = 0;
@@ -551,8 +553,10 @@ class Internals {
       kIsolateFastApiCallTargetOffset + kApiSystemPointerSize;
   static const int kIsolateThreadLocalTopOffset =
       kIsolateLongTaskStatsCounterOffset + kApiSizetSize;
-  static const int kIsolateEmbedderDataOffset =
+  static const int kIsolateHandleScopeDataOffset =
       kIsolateThreadLocalTopOffset + kThreadLocalTopSize;
+  static const int kIsolateEmbedderDataOffset =
+      kIsolateHandleScopeDataOffset + kHandleScopeDataSize;
 #ifdef V8_COMPRESS_POINTERS
   static const int kIsolateExternalPointerTableOffset =
       kIsolateEmbedderDataOffset + kNumIsolateDataSlots * kApiSystemPointerSize;
@@ -900,57 +904,6 @@ class BackingStoreBase {};
 // The maximum value in enum GarbageCollectionReason, defined in heap.h.
 // This is needed for histograms sampling garbage collection reasons.
 constexpr int kGarbageCollectionReasonMaxValue = 27;
-
-// Helper functions about values contained in handles.
-class ValueHelper final {
- public:
-#ifdef V8_ENABLE_CONSERVATIVE_STACK_SCANNING
-  static constexpr Address kLocalTaggedNullAddress = 1;
-
-  template <typename T>
-  static constexpr T* EmptyValue() {
-    return reinterpret_cast<T*>(kLocalTaggedNullAddress);
-  }
-
-  template <typename T>
-  V8_INLINE static Address ValueAsAddress(const T* value) {
-    return reinterpret_cast<Address>(value);
-  }
-
-  template <typename T, typename S>
-  V8_INLINE static T* SlotAsValue(S* slot) {
-    return *reinterpret_cast<T**>(slot);
-  }
-
-  template <typename T>
-  V8_INLINE static T* ValueAsSlot(T* const& value) {
-    return reinterpret_cast<T*>(const_cast<T**>(&value));
-  }
-
-#else  // !V8_ENABLE_CONSERVATIVE_STACK_SCANNING
-
-  template <typename T>
-  static constexpr T* EmptyValue() {
-    return nullptr;
-  }
-
-  template <typename T>
-  V8_INLINE static Address ValueAsAddress(const T* value) {
-    return *reinterpret_cast<const Address*>(value);
-  }
-
-  template <typename T, typename S>
-  V8_INLINE static T* SlotAsValue(S* slot) {
-    return reinterpret_cast<T*>(slot);
-  }
-
-  template <typename T>
-  V8_INLINE static T* ValueAsSlot(T* const& value) {
-    return value;
-  }
-
-#endif  // V8_ENABLE_CONSERVATIVE_STACK_SCANNING
-};
 
 }  // namespace internal
 }  // namespace v8

--- a/v8_c_api/src/v8include/v8-isolate.h
+++ b/v8_c_api/src/v8include/v8-isolate.h
@@ -536,6 +536,10 @@ class V8_EXPORT Isolate {
     kDurationFormat = 117,
     kInvalidatedNumberStringPrototypeNoReplaceProtector = 118,
     kRegExpUnicodeSetIncompatibilitiesWithUnicodeMode = 119,  // Unused.
+    kImportAssertionDeprecatedSyntax = 120,
+    kLocaleInfoObsoletedGetters = 121,
+    kLocaleInfoFunctions = 122,
+    kCompileHintsMagicAll = 123,
 
     // If you add new values here, you'll also need to update Chromium's:
     // web_feature.mojom, use_counter_callback.cc, and enums.xml. V8 changes to
@@ -1506,12 +1510,6 @@ class V8_EXPORT Isolate {
 
   void SetWasmLoadSourceMapCallback(WasmLoadSourceMapCallback callback);
 
-  V8_DEPRECATED("Wasm SIMD is always enabled")
-  void SetWasmSimdEnabledCallback(WasmSimdEnabledCallback callback);
-
-  V8_DEPRECATED("Wasm exceptions are always enabled")
-  void SetWasmExceptionsEnabledCallback(WasmExceptionsEnabledCallback callback);
-
   /**
    * Register callback to control whehter Wasm GC is enabled.
    * The callback overwrites the value of the flag.
@@ -1673,10 +1671,11 @@ uint32_t Isolate::GetNumberOfDataSlots() {
 
 template <class T>
 MaybeLocal<T> Isolate::GetDataFromSnapshotOnce(size_t index) {
-  T* data =
-      internal::ValueHelper::SlotAsValue<T>(GetDataFromSnapshotOnce(index));
-  if (data) internal::PerformCastCheck(data);
-  return Local<T>(data);
+  auto slot = GetDataFromSnapshotOnce(index);
+  if (slot) {
+    internal::PerformCastCheck(internal::ValueHelper::SlotAsValue<T>(slot));
+  }
+  return Local<T>::FromSlot(slot);
 }
 
 }  // namespace v8

--- a/v8_c_api/src/v8include/v8-local-handle.h
+++ b/v8_c_api/src/v8include/v8-local-handle.h
@@ -9,29 +9,42 @@
 
 #include <type_traits>
 
-#include "v8-internal.h"  // NOLINT(build/include_directory)
+#include "v8-handle-base.h"  // NOLINT(build/include_directory)
 
 namespace v8 {
 
-class Boolean;
+template <class T>
+class LocalBase;
+template <class T>
+class Local;
+template <class F>
+class MaybeLocal;
+
+template <class T>
+class Eternal;
+template <class T>
+class Global;
+
+template <class T>
+class NonCopyablePersistentTraits;
+template <class T>
+class PersistentBase;
+template <class T, class M = NonCopyablePersistentTraits<T>>
+class Persistent;
+
+class TracedReferenceBase;
 template <class T>
 class BasicTracedReference;
+template <class F>
+class TracedReference;
+
+class Boolean;
 class Context;
 class EscapableHandleScope;
 template <class F>
-class Eternal;
-template <class F>
 class FunctionCallbackInfo;
 class Isolate;
-template <class F>
-class MaybeLocal;
-template <class T>
-class NonCopyablePersistentTraits;
 class Object;
-template <class T, class M = NonCopyablePersistentTraits<T>>
-class Persistent;
-template <class T>
-class PersistentBase;
 template <class F1, class F2, class F3>
 class PersistentValueMapBase;
 template <class F1, class F2>
@@ -45,9 +58,6 @@ class ReturnValue;
 class String;
 template <class F>
 class Traced;
-template <class F>
-class TracedReference;
-class TracedReferenceBase;
 class Utils;
 
 namespace debug {
@@ -120,9 +130,9 @@ class V8_EXPORT V8_NODISCARD HandleScope {
   internal::Address* prev_next_;
   internal::Address* prev_limit_;
 
-  // Local::New uses CreateHandle with an Isolate* parameter.
-  template <class F>
-  friend class Local;
+  // LocalBase<T>::New uses CreateHandle with an Isolate* parameter.
+  template <typename T>
+  friend class LocalBase;
 
   // Object::GetInternalField and Context::GetEmbedderData use CreateHandle with
   // a HeapObject in their shortcuts.
@@ -130,32 +140,74 @@ class V8_EXPORT V8_NODISCARD HandleScope {
   friend class Context;
 };
 
-namespace internal {
-
 /**
- * Helper functions about handles.
+ * A base class for local handles.
+ * Its implementation depends on whether direct local support is enabled.
+ * When it is, a local handle contains a direct pointer to the referenced
+ * object, otherwise it contains an indirect pointer.
  */
-class HandleHelper final {
- public:
-  /**
-   * Checks whether two handles are equal.
-   * They are equal iff they are both empty or they are both non-empty and the
-   * objects to which they refer are physically equal.
-   *
-   * If both handles refer to JS objects, this is the same as strict equality.
-   * For primitives, such as numbers or strings, a `false` return value does not
-   * indicate that the values aren't equal in the JavaScript sense.
-   * Use `Value::StrictEquals()` to check primitives for equality.
-   */
-  template <typename T1, typename T2>
-  V8_INLINE static bool EqualHandles(const T1& lhs, const T2& rhs) {
-    if (lhs.IsEmpty()) return rhs.IsEmpty();
-    if (rhs.IsEmpty()) return false;
-    return lhs.address() == rhs.address();
+#ifdef V8_ENABLE_DIRECT_LOCAL
+
+template <typename T>
+class LocalBase : public DirectHandleBase {
+ protected:
+  template <class F>
+  friend class Local;
+
+  V8_INLINE LocalBase() = default;
+
+  V8_INLINE explicit LocalBase(internal::Address ptr) : DirectHandleBase(ptr) {}
+
+  template <typename S>
+  V8_INLINE LocalBase(const LocalBase<S>& other) : DirectHandleBase(other) {}
+
+  V8_INLINE static LocalBase<T> New(Isolate* isolate, internal::Address value) {
+    return LocalBase<T>(value);
+  }
+
+  V8_INLINE static LocalBase<T> New(Isolate* isolate, T* that) {
+    return LocalBase<T>::New(isolate,
+                             internal::ValueHelper::ValueAsAddress(that));
+  }
+
+  V8_INLINE static LocalBase<T> FromSlot(internal::Address* slot) {
+    return LocalBase<T>(*slot);
   }
 };
 
-}  // namespace internal
+#else  // !V8_ENABLE_DIRECT_LOCAL
+
+template <typename T>
+class LocalBase : public IndirectHandleBase {
+ protected:
+  template <class F>
+  friend class Local;
+
+  V8_INLINE LocalBase() = default;
+
+  V8_INLINE explicit LocalBase(internal::Address* location)
+      : IndirectHandleBase(location) {}
+
+  template <typename S>
+  V8_INLINE LocalBase(const LocalBase<S>& other) : IndirectHandleBase(other) {}
+
+  V8_INLINE static LocalBase<T> New(Isolate* isolate, internal::Address value) {
+    return LocalBase(HandleScope::CreateHandle(
+        reinterpret_cast<internal::Isolate*>(isolate), value));
+  }
+
+  V8_INLINE static LocalBase<T> New(Isolate* isolate, T* that) {
+    if (internal::ValueHelper::IsEmpty(that)) return LocalBase<T>();
+    return LocalBase<T>::New(isolate,
+                             internal::ValueHelper::ValueAsAddress(that));
+  }
+
+  V8_INLINE static LocalBase<T> FromSlot(internal::Address* slot) {
+    return LocalBase<T>(slot);
+  }
+};
+
+#endif  // V8_ENABLE_DIRECT_LOCAL
 
 /**
  * An object reference managed by the v8 garbage collector.
@@ -187,12 +239,12 @@ class HandleHelper final {
  * to these values as to their handles.
  */
 template <class T>
-class Local {
+class Local : public LocalBase<T> {
  public:
-  V8_INLINE Local() : val_(internal::ValueHelper::EmptyValue<T>()) {}
+  V8_INLINE Local() = default;
 
   template <class S>
-  V8_INLINE Local(Local<S> that) : val_(reinterpret_cast<T*>(*that)) {
+  V8_INLINE Local(Local<S> that) : LocalBase<T>(that) {
     /**
      * This check fails when trying to convert between incompatible
      * handles. For example, converting from a Local<String> to a
@@ -201,21 +253,9 @@ class Local {
     static_assert(std::is_base_of<T, S>::value, "type check");
   }
 
-  /**
-   * Returns true if the handle is empty.
-   */
-  V8_INLINE bool IsEmpty() const {
-    return val_ == internal::ValueHelper::EmptyValue<T>();
-  }
+  V8_INLINE T* operator->() const { return this->template value<T>(); }
 
-  /**
-   * Sets the handle to be empty. IsEmpty() will then return true.
-   */
-  V8_INLINE void Clear() { val_ = internal::ValueHelper::EmptyValue<T>(); }
-
-  V8_INLINE T* operator->() const { return val_; }
-
-  V8_INLINE T* operator*() const { return val_; }
+  V8_INLINE T* operator*() const { return this->operator->(); }
 
   /**
    * Checks whether two handles are equal or different.
@@ -259,8 +299,9 @@ class Local {
     // If we're going to perform the type check then we have to check
     // that the handle isn't empty before doing the checked cast.
     if (that.IsEmpty()) return Local<T>();
+    T::Cast(that.template value<S>());
 #endif
-    return Local<T>(T::Cast(*that));
+    return Local<T>(LocalBase<T>(that));
   }
 
   /**
@@ -279,17 +320,17 @@ class Local {
    * the original handle is destroyed/disposed.
    */
   V8_INLINE static Local<T> New(Isolate* isolate, Local<T> that) {
-    return New(isolate, that.val_);
+    return New(isolate, that.template value<T>());
   }
 
   V8_INLINE static Local<T> New(Isolate* isolate,
                                 const PersistentBase<T>& that) {
-    return New(isolate, internal::ValueHelper::SlotAsValue<T>(that.val_));
+    return New(isolate, that.template value<T>());
   }
 
   V8_INLINE static Local<T> New(Isolate* isolate,
                                 const BasicTracedReference<T>& that) {
-    return New(isolate, internal::ValueHelper::SlotAsValue<T>(*that));
+    return New(isolate, that.template value<T>());
   }
 
  private:
@@ -298,7 +339,13 @@ class Local {
   template <class F>
   friend class Eternal;
   template <class F>
+  friend class Global;
+  template <class F>
+  friend class Local;
+  template <class F>
   friend class MaybeLocal;
+  template <class F, class M>
+  friend class Persistent;
   template <class F>
   friend class FunctionCallbackInfo;
   template <class F>
@@ -328,28 +375,26 @@ class Local {
   friend class internal::HandleHelper;
   friend class debug::ConsoleCallArguments;
 
-  explicit V8_INLINE Local(T* that) : val_(that) {}
-
-  V8_INLINE internal::Address address() const {
-    return internal::ValueHelper::ValueAsAddress(val_);
-  }
+  V8_INLINE explicit Local<T>(const LocalBase<T>& other)
+      : LocalBase<T>(other) {}
 
   V8_INLINE static Local<T> FromSlot(internal::Address* slot) {
-    return Local<T>(internal::ValueHelper::SlotAsValue<T>(slot));
+    return Local<T>(LocalBase<T>::FromSlot(slot));
+  }
+
+  V8_INLINE static Local<T> New(Isolate* isolate, internal::Address value) {
+    return Local<T>(LocalBase<T>::New(isolate, value));
   }
 
   V8_INLINE static Local<T> New(Isolate* isolate, T* that) {
-#ifdef V8_ENABLE_CONSERVATIVE_STACK_SCANNING
-    return Local<T>(that);
-#else
-    if (that == nullptr) return Local<T>();
-    internal::Address* p = reinterpret_cast<internal::Address*>(that);
-    return Local<T>(reinterpret_cast<T*>(HandleScope::CreateHandle(
-        reinterpret_cast<internal::Isolate*>(isolate), *p)));
-#endif
+    return Local<T>(LocalBase<T>::New(isolate, that));
   }
 
-  T* val_;
+  // Unsafe cast, should be avoided.
+  template <class S>
+  V8_INLINE Local<S> UnsafeAs() const {
+    return Local<S>(LocalBase<S>(*this));
+  }
 };
 
 #if !defined(V8_IMMINENT_DEPRECATION_WARNINGS)
@@ -371,15 +416,11 @@ using Handle = Local<T>;
 template <class T>
 class MaybeLocal {
  public:
-  V8_INLINE MaybeLocal() : val_(internal::ValueHelper::EmptyValue<T>()) {}
+  V8_INLINE MaybeLocal() : local_() {}
   template <class S>
-  V8_INLINE MaybeLocal(Local<S> that) : val_(reinterpret_cast<T*>(*that)) {
-    static_assert(std::is_base_of<T, S>::value, "type check");
-  }
+  V8_INLINE MaybeLocal(Local<S> that) : local_(that) {}
 
-  V8_INLINE bool IsEmpty() const {
-    return val_ == internal::ValueHelper::EmptyValue<T>();
-  }
+  V8_INLINE bool IsEmpty() const { return local_.IsEmpty(); }
 
   /**
    * Converts this MaybeLocal<> to a Local<>. If this MaybeLocal<> is empty,
@@ -387,7 +428,7 @@ class MaybeLocal {
    */
   template <class S>
   V8_WARN_UNUSED_RESULT V8_INLINE bool ToLocal(Local<S>* out) const {
-    out->val_ = IsEmpty() ? internal::ValueHelper::EmptyValue<T>() : this->val_;
+    *out = local_;
     return !IsEmpty();
   }
 
@@ -397,7 +438,7 @@ class MaybeLocal {
    */
   V8_INLINE Local<T> ToLocalChecked() {
     if (V8_UNLIKELY(IsEmpty())) api_internal::ToLocalEmpty();
-    return Local<T>(val_);
+    return local_;
   }
 
   /**
@@ -406,11 +447,11 @@ class MaybeLocal {
    */
   template <class S>
   V8_INLINE Local<S> FromMaybe(Local<S> default_value) const {
-    return IsEmpty() ? default_value : Local<S>(val_);
+    return IsEmpty() ? default_value : Local<S>(local_);
   }
 
  private:
-  T* val_;
+  Local<T> local_;
 };
 
 /**
@@ -428,12 +469,10 @@ class V8_EXPORT V8_NODISCARD EscapableHandleScope : public HandleScope {
    */
   template <class T>
   V8_INLINE Local<T> Escape(Local<T> value) {
-#ifdef V8_ENABLE_CONSERVATIVE_STACK_SCANNING
+#ifdef V8_ENABLE_DIRECT_LOCAL
     return value;
 #else
-    internal::Address* slot =
-        Escape(reinterpret_cast<internal::Address*>(*value));
-    return Local<T>(reinterpret_cast<T*>(slot));
+    return Local<T>::FromSlot(Escape(value.slot()));
 #endif
   }
 

--- a/v8_c_api/src/v8include/v8-persistent-handle.h
+++ b/v8_c_api/src/v8include/v8-persistent-handle.h
@@ -26,7 +26,7 @@ class PersistentValueMap;
 class Value;
 
 namespace api_internal {
-V8_EXPORT Value* Eternalize(v8::Isolate* isolate, Value* handle);
+V8_EXPORT internal::Address* Eternalize(v8::Isolate* isolate, Value* handle);
 V8_EXPORT internal::Address* CopyGlobalReference(internal::Address* from);
 V8_EXPORT void DisposeGlobal(internal::Address* global_handle);
 V8_EXPORT void MakeWeak(internal::Address** location_addr);
@@ -34,7 +34,7 @@ V8_EXPORT void* ClearWeak(internal::Address* location);
 V8_EXPORT void AnnotateStrongRetainer(internal::Address* location,
                                       const char* label);
 V8_EXPORT internal::Address* GlobalizeReference(internal::Isolate* isolate,
-                                                internal::Address* handle);
+                                                internal::Address value);
 V8_EXPORT void MoveGlobalReference(internal::Address** from,
                                    internal::Address** to);
 }  // namespace api_internal
@@ -44,35 +44,28 @@ V8_EXPORT void MoveGlobalReference(internal::Address** from,
  * isolate.
  */
 template <class T>
-class Eternal {
+class Eternal : public IndirectHandleBase {
  public:
-  V8_INLINE Eternal() : val_(nullptr) {}
+  V8_INLINE Eternal() = default;
+
   template <class S>
-  V8_INLINE Eternal(Isolate* isolate, Local<S> handle) : val_(nullptr) {
+  V8_INLINE Eternal(Isolate* isolate, Local<S> handle) {
     Set(isolate, handle);
   }
+
   // Can only be safely called if already set.
   V8_INLINE Local<T> Get(Isolate* isolate) const {
     // The eternal handle will never go away, so as with the roots, we don't
     // even need to open a handle.
-    return Local<T>(internal::ValueHelper::SlotAsValue<T>(val_));
+    return Local<T>::FromSlot(slot());
   }
-
-  V8_INLINE bool IsEmpty() const { return val_ == nullptr; }
 
   template <class S>
   void Set(Isolate* isolate, Local<S> handle) {
     static_assert(std::is_base_of<T, S>::value, "type check");
-    val_ = reinterpret_cast<T*>(
-        api_internal::Eternalize(isolate, reinterpret_cast<Value*>(*handle)));
+    slot() =
+        api_internal::Eternalize(isolate, *handle.template UnsafeAs<Value>());
   }
-
- private:
-  V8_INLINE internal::Address address() const {
-    return *reinterpret_cast<internal::Address*>(val_);
-  }
-
-  T* val_;
 };
 
 namespace api_internal {
@@ -95,7 +88,7 @@ V8_EXPORT void MakeWeak(internal::Address* location, void* data,
  *
  */
 template <class T>
-class PersistentBase {
+class PersistentBase : public IndirectHandleBase {
  public:
   /**
    * If non-empty, destroy the underlying storage cell
@@ -116,9 +109,6 @@ class PersistentBase {
    */
   template <class S>
   V8_INLINE void Reset(Isolate* isolate, const PersistentBase<S>& other);
-
-  V8_INLINE bool IsEmpty() const { return val_ == nullptr; }
-  V8_INLINE void Empty() { val_ = 0; }
 
   V8_INLINE Local<T> Get(Isolate* isolate) const {
     return Local<T>::New(isolate, *this);
@@ -217,18 +207,14 @@ class PersistentBase {
   template <class F1, class F2>
   friend class PersistentValueVector;
   friend class Object;
-  friend class internal::HandleHelper;
+  friend class internal::ValueHelper;
 
-  explicit V8_INLINE PersistentBase(T* val) : val_(val) {}
-  V8_INLINE T* operator*() const { return this->val_; }
-  V8_INLINE internal::Address address() const {
-    return *reinterpret_cast<internal::Address*>(val_);
-  }
+  V8_INLINE PersistentBase() = default;
 
-  V8_INLINE static T* New(Isolate* isolate, Local<T> that);
-  V8_INLINE static T* New(Isolate* isolate, T* that);
+  V8_INLINE explicit PersistentBase(internal::Address* location)
+      : IndirectHandleBase(location) {}
 
-  T* val_;
+  V8_INLINE static internal::Address* New(Isolate* isolate, T* that);
 };
 
 /**
@@ -279,16 +265,17 @@ class Persistent : public PersistentBase<T> {
   /**
    * A Persistent with no storage cell.
    */
-  V8_INLINE Persistent() : PersistentBase<T>(nullptr) {}
+  V8_INLINE Persistent() = default;
+
   /**
    * Construct a Persistent from a Local.
    * When the Local is non-empty, a new storage cell is created
    * pointing to the same object, and no flags are set.
    */
-
   template <class S>
   V8_INLINE Persistent(Isolate* isolate, Local<S> that)
-      : PersistentBase<T>(PersistentBase<T>::New(isolate, that)) {
+      : PersistentBase<T>(
+            PersistentBase<T>::New(isolate, that.template value<S>())) {
     static_assert(std::is_base_of<T, S>::value, "type check");
   }
 
@@ -299,20 +286,22 @@ class Persistent : public PersistentBase<T> {
    */
   template <class S, class M2>
   V8_INLINE Persistent(Isolate* isolate, const Persistent<S, M2>& that)
-      : PersistentBase<T>(PersistentBase<T>::New(isolate, *that)) {
+      : PersistentBase<T>(
+            PersistentBase<T>::New(isolate, that.template value<S>())) {
     static_assert(std::is_base_of<T, S>::value, "type check");
   }
+
   /**
    * The copy constructors and assignment operator create a Persistent
    * exactly as the Persistent constructor, but the Copy function from the
    * traits class is called, allowing the setting of flags based on the
    * copied Persistent.
    */
-  V8_INLINE Persistent(const Persistent& that) : PersistentBase<T>(nullptr) {
+  V8_INLINE Persistent(const Persistent& that) : PersistentBase<T>() {
     Copy(that);
   }
   template <class S, class M2>
-  V8_INLINE Persistent(const Persistent<S, M2>& that) : PersistentBase<T>(0) {
+  V8_INLINE Persistent(const Persistent<S, M2>& that) : PersistentBase<T>() {
     Copy(that);
   }
   V8_INLINE Persistent& operator=(const Persistent& that) {
@@ -324,6 +313,7 @@ class Persistent : public PersistentBase<T> {
     Copy(that);
     return *this;
   }
+
   /**
    * The destructor will dispose the Persistent based on the
    * kResetInDestructor flags in the traits class.  Since not calling dispose
@@ -334,20 +324,21 @@ class Persistent : public PersistentBase<T> {
   }
 
   // TODO(dcarney): this is pretty useless, fix or remove
-  template <class S>
-  V8_INLINE static Persistent<T>& Cast(const Persistent<S>& that) {
+  template <class S, class M2>
+  V8_INLINE static Persistent<T, M>& Cast(const Persistent<S, M2>& that) {
 #ifdef V8_ENABLE_CHECKS
     // If we're going to perform the type check then we have to check
     // that the handle isn't empty before doing the checked cast.
-    if (!that.IsEmpty()) T::Cast(*that);
+    if (!that.IsEmpty()) T::Cast(that.template value<S>());
 #endif
-    return reinterpret_cast<Persistent<T>&>(const_cast<Persistent<S>&>(that));
+    return reinterpret_cast<Persistent<T, M>&>(
+        const_cast<Persistent<S, M2>&>(that));
   }
 
   // TODO(dcarney): this is pretty useless, fix or remove
-  template <class S>
-  V8_INLINE Persistent<S>& As() const {
-    return Persistent<S>::Cast(*this);
+  template <class S, class M2>
+  V8_INLINE Persistent<S, M2>& As() const {
+    return Persistent<S, M2>::Cast(*this);
   }
 
  private:
@@ -360,7 +351,6 @@ class Persistent : public PersistentBase<T> {
   template <class F>
   friend class ReturnValue;
 
-  explicit V8_INLINE Persistent(T* that) : PersistentBase<T>(that) {}
   template <class S, class M2>
   V8_INLINE void Copy(const Persistent<S, M2>& that);
 };
@@ -376,7 +366,7 @@ class Global : public PersistentBase<T> {
   /**
    * A Global with no storage cell.
    */
-  V8_INLINE Global() : PersistentBase<T>(nullptr) {}
+  V8_INLINE Global() = default;
 
   /**
    * Construct a Global from a Local.
@@ -385,7 +375,8 @@ class Global : public PersistentBase<T> {
    */
   template <class S>
   V8_INLINE Global(Isolate* isolate, Local<S> that)
-      : PersistentBase<T>(PersistentBase<T>::New(isolate, that)) {
+      : PersistentBase<T>(
+            PersistentBase<T>::New(isolate, that.template value<S>())) {
     static_assert(std::is_base_of<T, S>::value, "type check");
   }
 
@@ -396,7 +387,8 @@ class Global : public PersistentBase<T> {
    */
   template <class S>
   V8_INLINE Global(Isolate* isolate, const PersistentBase<S>& that)
-      : PersistentBase<T>(PersistentBase<T>::New(isolate, that.val_)) {
+      : PersistentBase<T>(
+            PersistentBase<T>::New(isolate, that.template value<S>())) {
     static_assert(std::is_base_of<T, S>::value, "type check");
   }
 
@@ -446,17 +438,11 @@ class V8_EXPORT PersistentHandleVisitor {
 };
 
 template <class T>
-T* PersistentBase<T>::New(Isolate* isolate, Local<T> that) {
-  return PersistentBase<T>::New(isolate,
-                                internal::ValueHelper::ValueAsSlot(*that));
-}
-
-template <class T>
-T* PersistentBase<T>::New(Isolate* isolate, T* that) {
-  if (that == nullptr) return nullptr;
-  internal::Address* p = reinterpret_cast<internal::Address*>(that);
-  return reinterpret_cast<T*>(api_internal::GlobalizeReference(
-      reinterpret_cast<internal::Isolate*>(isolate), p));
+internal::Address* PersistentBase<T>::New(Isolate* isolate, T* that) {
+  if (internal::ValueHelper::IsEmpty(that)) return nullptr;
+  return api_internal::GlobalizeReference(
+      reinterpret_cast<internal::Isolate*>(isolate),
+      internal::ValueHelper::ValueAsAddress(that));
 }
 
 template <class T, class M>
@@ -465,8 +451,7 @@ void Persistent<T, M>::Copy(const Persistent<S, M2>& that) {
   static_assert(std::is_base_of<T, S>::value, "type check");
   this->Reset();
   if (that.IsEmpty()) return;
-  internal::Address* p = reinterpret_cast<internal::Address*>(that.val_);
-  this->val_ = reinterpret_cast<T*>(api_internal::CopyGlobalReference(p));
+  this->slot() = api_internal::CopyGlobalReference(that.slot());
   M::Copy(that, this);
 }
 
@@ -474,15 +459,14 @@ template <class T>
 bool PersistentBase<T>::IsWeak() const {
   using I = internal::Internals;
   if (this->IsEmpty()) return false;
-  return I::GetNodeState(reinterpret_cast<internal::Address*>(this->val_)) ==
-         I::kNodeStateIsWeakValue;
+  return I::GetNodeState(this->slot()) == I::kNodeStateIsWeakValue;
 }
 
 template <class T>
 void PersistentBase<T>::Reset() {
   if (this->IsEmpty()) return;
-  api_internal::DisposeGlobal(reinterpret_cast<internal::Address*>(this->val_));
-  val_ = nullptr;
+  api_internal::DisposeGlobal(this->slot());
+  this->Clear();
 }
 
 /**
@@ -495,7 +479,7 @@ void PersistentBase<T>::Reset(Isolate* isolate, const Local<S>& other) {
   static_assert(std::is_base_of<T, S>::value, "type check");
   Reset();
   if (other.IsEmpty()) return;
-  this->val_ = New(isolate, internal::ValueHelper::ValueAsSlot(*other));
+  this->slot() = New(isolate, *other);
 }
 
 /**
@@ -509,7 +493,7 @@ void PersistentBase<T>::Reset(Isolate* isolate,
   static_assert(std::is_base_of<T, S>::value, "type check");
   Reset();
   if (other.IsEmpty()) return;
-  this->val_ = New(isolate, other.val_);
+  this->slot() = New(isolate, other.template value<S>());
 }
 
 template <class T>
@@ -522,8 +506,8 @@ V8_INLINE void PersistentBase<T>::SetWeak(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
-  api_internal::MakeWeak(reinterpret_cast<internal::Address*>(this->val_),
-                         parameter, reinterpret_cast<Callback>(callback), type);
+  api_internal::MakeWeak(this->slot(), parameter,
+                         reinterpret_cast<Callback>(callback), type);
 #if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
@@ -531,28 +515,25 @@ V8_INLINE void PersistentBase<T>::SetWeak(
 
 template <class T>
 void PersistentBase<T>::SetWeak() {
-  api_internal::MakeWeak(reinterpret_cast<internal::Address**>(&this->val_));
+  api_internal::MakeWeak(&this->slot());
 }
 
 template <class T>
 template <typename P>
 P* PersistentBase<T>::ClearWeak() {
-  return reinterpret_cast<P*>(api_internal::ClearWeak(
-      reinterpret_cast<internal::Address*>(this->val_)));
+  return reinterpret_cast<P*>(api_internal::ClearWeak(this->slot()));
 }
 
 template <class T>
 void PersistentBase<T>::AnnotateStrongRetainer(const char* label) {
-  api_internal::AnnotateStrongRetainer(
-      reinterpret_cast<internal::Address*>(this->val_), label);
+  api_internal::AnnotateStrongRetainer(this->slot(), label);
 }
 
 template <class T>
 void PersistentBase<T>::SetWrapperClassId(uint16_t class_id) {
   using I = internal::Internals;
   if (this->IsEmpty()) return;
-  internal::Address* obj = reinterpret_cast<internal::Address*>(this->val_);
-  uint8_t* addr = reinterpret_cast<uint8_t*>(obj) + I::kNodeClassIdOffset;
+  uint8_t* addr = reinterpret_cast<uint8_t*>(slot()) + I::kNodeClassIdOffset;
   *reinterpret_cast<uint16_t*>(addr) = class_id;
 }
 
@@ -560,18 +541,15 @@ template <class T>
 uint16_t PersistentBase<T>::WrapperClassId() const {
   using I = internal::Internals;
   if (this->IsEmpty()) return 0;
-  internal::Address* obj = reinterpret_cast<internal::Address*>(this->val_);
-  uint8_t* addr = reinterpret_cast<uint8_t*>(obj) + I::kNodeClassIdOffset;
+  uint8_t* addr = reinterpret_cast<uint8_t*>(slot()) + I::kNodeClassIdOffset;
   return *reinterpret_cast<uint16_t*>(addr);
 }
 
 template <class T>
-Global<T>::Global(Global&& other) : PersistentBase<T>(other.val_) {
-  if (other.val_ != nullptr) {
-    api_internal::MoveGlobalReference(
-        reinterpret_cast<internal::Address**>(&other.val_),
-        reinterpret_cast<internal::Address**>(&this->val_));
-    other.val_ = nullptr;
+Global<T>::Global(Global&& other) : PersistentBase<T>(other.slot()) {
+  if (!other.IsEmpty()) {
+    api_internal::MoveGlobalReference(&other.slot(), &this->slot());
+    other.Clear();
   }
 }
 
@@ -581,12 +559,10 @@ Global<T>& Global<T>::operator=(Global<S>&& rhs) {
   static_assert(std::is_base_of<T, S>::value, "type check");
   if (this != &rhs) {
     this->Reset();
-    if (rhs.val_ != nullptr) {
-      this->val_ = rhs.val_;
-      api_internal::MoveGlobalReference(
-          reinterpret_cast<internal::Address**>(&rhs.val_),
-          reinterpret_cast<internal::Address**>(&this->val_));
-      rhs.val_ = nullptr;
+    if (!rhs.IsEmpty()) {
+      this->slot() = rhs.slot();
+      api_internal::MoveGlobalReference(&rhs.slot(), &this->slot());
+      rhs.Clear();
     }
   }
   return *this;

--- a/v8_c_api/src/v8include/v8-primitive.h
+++ b/v8_c_api/src/v8include/v8-primitive.h
@@ -493,7 +493,7 @@ class V8_EXPORT String : public Name {
   /**
    * Returns true if this string can be made external.
    */
-  V8_DEPRECATE_SOON("Use the version that takes an encoding as argument.")
+  V8_DEPRECATED("Use the version that takes an encoding as argument.")
   bool CanMakeExternal() const;
 
   /**

--- a/v8_c_api/src/v8include/v8-profiler.h
+++ b/v8_c_api/src/v8include/v8-profiler.h
@@ -24,7 +24,7 @@ enum class EmbedderStateTag : uint8_t;
 class HeapGraphNode;
 struct HeapStatsUpdate;
 class Object;
-enum StateTag : int;
+enum StateTag : uint16_t;
 
 using NativeObject = void*;
 using SnapshotObjectId = uint32_t;
@@ -882,6 +882,15 @@ class V8_EXPORT EmbedderGraph {
      * object graph.
      */
     virtual Detachedness GetDetachedness() { return Detachedness::kUnknown; }
+
+    /**
+     * Returns the address of the object in the embedder heap, or nullptr to not
+     * specify the address. If this address is provided, then V8 can generate
+     * consistent IDs for objects across subsequent heap snapshots, which allows
+     * devtools to determine which objects were retained from one snapshot to
+     * the next. This value is used only if GetNativeObject returns nullptr.
+     */
+    virtual const void* GetAddress() { return nullptr; }
 
     Node(const Node&) = delete;
     Node& operator=(const Node&) = delete;

--- a/v8_c_api/src/v8include/v8-snapshot.h
+++ b/v8_c_api/src/v8include/v8-snapshot.h
@@ -88,10 +88,13 @@ class V8_EXPORT SnapshotCreator {
    * \param existing_blob existing snapshot from which to create this one.
    * \param external_references a null-terminated array of external references
    *        that must be equivalent to CreateParams::external_references.
+   * \param owns_isolate whether this SnapshotCreator should call
+   *        v8::Isolate::Dispose() during its destructor.
    */
   SnapshotCreator(Isolate* isolate,
                   const intptr_t* external_references = nullptr,
-                  const StartupData* existing_blob = nullptr);
+                  const StartupData* existing_blob = nullptr,
+                  bool owns_isolate = true);
 
   /**
    * Create and enter an isolate, and set it up for serialization.

--- a/v8_c_api/src/v8include/v8-source-location.h
+++ b/v8_c_api/src/v8include/v8-source-location.h
@@ -1,0 +1,92 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef INCLUDE_SOURCE_LOCATION_H_
+#define INCLUDE_SOURCE_LOCATION_H_
+
+#include <cstddef>
+#include <string>
+
+#include "v8config.h"  // NOLINT(build/include_directory)
+
+#if defined(__has_builtin)
+#define V8_SUPPORTS_SOURCE_LOCATION                                      \
+  (__has_builtin(__builtin_FUNCTION) && __has_builtin(__builtin_FILE) && \
+   __has_builtin(__builtin_LINE))  // NOLINT
+#elif defined(V8_CC_GNU) && __GNUC__ >= 7
+#define V8_SUPPORTS_SOURCE_LOCATION 1
+#elif defined(V8_CC_INTEL) && __ICC >= 1800
+#define V8_SUPPORTS_SOURCE_LOCATION 1
+#else
+#define V8_SUPPORTS_SOURCE_LOCATION 0
+#endif
+
+namespace v8 {
+
+/**
+ * Encapsulates source location information. Mimics C++20's
+ * `std::source_location`.
+ */
+class V8_EXPORT SourceLocation final {
+ public:
+  /**
+   * Construct source location information corresponding to the location of the
+   * call site.
+   */
+#if V8_SUPPORTS_SOURCE_LOCATION
+  static constexpr SourceLocation Current(
+      const char* function = __builtin_FUNCTION(),
+      const char* file = __builtin_FILE(), size_t line = __builtin_LINE()) {
+    return SourceLocation(function, file, line);
+  }
+#else
+  static constexpr SourceLocation Current() { return SourceLocation(); }
+#endif  // V8_SUPPORTS_SOURCE_LOCATION
+
+  /**
+   * Constructs unspecified source location information.
+   */
+  constexpr SourceLocation() = default;
+
+  /**
+   * Returns the name of the function associated with the position represented
+   * by this object, if any.
+   *
+   * \returns the function name as cstring.
+   */
+  constexpr const char* Function() const { return function_; }
+
+  /**
+   * Returns the name of the current source file represented by this object.
+   *
+   * \returns the file name as cstring.
+   */
+  constexpr const char* FileName() const { return file_; }
+
+  /**
+   * Returns the line number represented by this object.
+   *
+   * \returns the line number.
+   */
+  constexpr size_t Line() const { return line_; }
+
+  /**
+   * Returns a human-readable string representing this object.
+   *
+   * \returns a human-readable string representing source location information.
+   */
+  std::string ToString() const;
+
+ private:
+  constexpr SourceLocation(const char* function, const char* file, size_t line)
+      : function_(function), file_(file), line_(line) {}
+
+  const char* function_ = nullptr;
+  const char* file_ = nullptr;
+  size_t line_ = 0u;
+};
+
+}  // namespace v8
+
+#endif  // INCLUDE_SOURCE_LOCATION_H_

--- a/v8_c_api/src/v8include/v8-unwinder.h
+++ b/v8_c_api/src/v8include/v8-unwinder.h
@@ -33,7 +33,7 @@ struct V8_EXPORT RegisterState {
 };
 
 // A StateTag represents a possible state of the VM.
-enum StateTag : int {
+enum StateTag : uint16_t {
   JS,
   GC,
   PARSER,

--- a/v8_c_api/src/v8include/v8-util.h
+++ b/v8_c_api/src/v8include/v8-util.h
@@ -182,7 +182,7 @@ class PersistentValueMapBase {
    */
   Local<V> Get(const K& key) {
     V* p = FromVal(Traits::Get(&impl_, key));
-#ifdef V8_ENABLE_CONSERVATIVE_STACK_SCANNING
+#ifdef V8_ENABLE_DIRECT_LOCAL
     if (p == nullptr) return Local<V>();
 #endif
     return Local<V>::New(isolate_, p);
@@ -302,13 +302,13 @@ class PersistentValueMapBase {
   }
 
   static PersistentContainerValue ClearAndLeak(Global<V>* persistent) {
-    V* v = persistent->val_;
-    persistent->val_ = nullptr;
+    V* v = persistent->template value<V>();
+    persistent->Clear();
     return reinterpret_cast<PersistentContainerValue>(v);
   }
 
   static PersistentContainerValue Leak(Global<V>* persistent) {
-    return reinterpret_cast<PersistentContainerValue>(persistent->val_);
+    return reinterpret_cast<PersistentContainerValue>(persistent->slot());
   }
 
   /**
@@ -318,7 +318,7 @@ class PersistentValueMapBase {
    */
   static Global<V> Release(PersistentContainerValue v) {
     Global<V> p;
-    p.val_ = FromVal(v);
+    p.slot() = reinterpret_cast<internal::Address*>(FromVal(v));
     if (Traits::kCallbackType != kNotWeak && p.IsWeak()) {
       Traits::DisposeCallbackData(
           p.template ClearWeak<typename Traits::WeakCallbackDataType>());
@@ -328,7 +328,8 @@ class PersistentValueMapBase {
 
   void RemoveWeak(const K& key) {
     Global<V> p;
-    p.val_ = FromVal(Traits::Remove(&impl_, key));
+    p.slot() = reinterpret_cast<internal::Address*>(
+        FromVal(Traits::Remove(&impl_, key)));
     p.Reset();
   }
 
@@ -396,7 +397,7 @@ class PersistentValueMap : public PersistentValueMapBase<K, V, Traits> {
           Traits::kCallbackType == kWeakWithInternalFields
               ? WeakCallbackType::kInternalFields
               : WeakCallbackType::kParameter;
-      Local<V> value(Local<V>::New(this->isolate(), *persistent));
+      auto value = Local<V>::New(this->isolate(), *persistent);
       persistent->template SetWeak<typename Traits::WeakCallbackDataType>(
           Traits::WeakCallbackParameter(this, key, value), WeakCallback,
           callback_type);
@@ -472,7 +473,7 @@ class GlobalValueMap : public PersistentValueMapBase<K, V, Traits> {
           Traits::kCallbackType == kWeakWithInternalFields
               ? WeakCallbackType::kInternalFields
               : WeakCallbackType::kParameter;
-      Local<V> value(Local<V>::New(this->isolate(), *persistent));
+      auto value = Local<V>::New(this->isolate(), *persistent);
       persistent->template SetWeak<typename Traits::WeakCallbackDataType>(
           Traits::WeakCallbackParameter(this, key, value), OnWeakCallback,
           callback_type);
@@ -629,7 +630,8 @@ class V8_DEPRECATE_SOON("Use std::vector<Global<V>>.") PersistentValueVector {
     size_t length = Traits::Size(&impl_);
     for (size_t i = 0; i < length; i++) {
       Global<V> p;
-      p.val_ = FromVal(Traits::Get(&impl_, i));
+      p.slot() =
+          reinterpret_cast<internal::Address>(FromVal(Traits::Get(&impl_, i)));
     }
     Traits::Clear(&impl_);
   }
@@ -644,9 +646,9 @@ class V8_DEPRECATE_SOON("Use std::vector<Global<V>>.") PersistentValueVector {
 
  private:
   static PersistentContainerValue ClearAndLeak(Global<V>* persistent) {
-    V* v = persistent->val_;
-    persistent->val_ = nullptr;
-    return reinterpret_cast<PersistentContainerValue>(v);
+    auto slot = persistent->slot();
+    persistent->Clear();
+    return reinterpret_cast<PersistentContainerValue>(slot);
   }
 
   static V* FromVal(PersistentContainerValue v) {

--- a/v8_c_api/src/v8include/v8-value-serializer.h
+++ b/v8_c_api/src/v8include/v8-value-serializer.h
@@ -76,6 +76,20 @@ class V8_EXPORT ValueSerializer {
     virtual void ThrowDataCloneError(Local<String> message) = 0;
 
     /**
+     * The embedder overrides this method to enable custom host object filter
+     * with Delegate::IsHostObject.
+     *
+     * This method is called at most once per serializer.
+     */
+    virtual bool HasCustomHostObject(Isolate* isolate);
+
+    /**
+     * The embedder overrides this method to determine if an JS object is a
+     * host object and needs to be serialized by the host.
+     */
+    virtual Maybe<bool> IsHostObject(Isolate* isolate, Local<Object> object);
+
+    /**
      * The embedder overrides this method to write some kind of host object, if
      * possible. If not, a suitable exception should be thrown and
      * Nothing<bool>() returned.

--- a/v8_c_api/src/v8include/v8-version.h
+++ b/v8_c_api/src/v8include/v8-version.h
@@ -9,9 +9,9 @@
 // NOTE these macros are used by some of the tool scripts and the build
 // system so their names cannot be changed without changing the scripts.
 #define V8_MAJOR_VERSION 11
-#define V8_MINOR_VERSION 3
-#define V8_BUILD_NUMBER 244
-#define V8_PATCH_LEVEL 12
+#define V8_MINOR_VERSION 4
+#define V8_BUILD_NUMBER 183
+#define V8_PATCH_LEVEL 17
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)


### PR DESCRIPTION
Adds a module called "inspector.rs" with corresponding relevant structures.

1. Changes ordinary comments to doc-comments on the C bindings.
2. Corrects the naming of C binding functions to follow the convention.
3. Makes the tests work and pass.
4. Uses the logging facility.
5. Updates the dependencies.
6. Removes comments.
7. Refactors the code a little.