### PR TITLE
Update v8 version to 11.4.183.25

### DIFF
--- a/.github/workflows/BUILD_LINUX_REUSABLE.yml
+++ b/.github/workflows/BUILD_LINUX_REUSABLE.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Build
       run: V8_VERSION=${{ inputs.v8_version }} V8_UPDATE_HEADERS=${{ inputs.v8_update_headers }} cargo build -vv
     - name: Run tests
-      run: V8_VERSION=${{ inputs.v8_version }} V8_UPDATE_HEADERS=${{ inputs.v8_update_headers }} cargo test -vv -- --test-threads 1
+      run: V8_VERSION=${{ inputs.v8_version }} V8_UPDATE_HEADERS=${{ inputs.v8_update_headers }} cargo test -vv

--- a/.github/workflows/BUILD_MAC_REUSABLE.yml
+++ b/.github/workflows/BUILD_MAC_REUSABLE.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Build
       run: V8_VERSION=${{ inputs.v8_version }} V8_UPDATE_HEADERS=${{ inputs.v8_update_headers }} cargo build --verbose
     - name: Run tests
-      run: V8_VERSION=${{ inputs.v8_version }} V8_UPDATE_HEADERS=${{ inputs.v8_update_headers }} cargo test --verbose -- --test-threads 1
+      run: V8_VERSION=${{ inputs.v8_version }} V8_UPDATE_HEADERS=${{ inputs.v8_update_headers }} cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = "1"
 
 [dev-dependencies]
 v8_rs_derive = { path = "./v8-rs-derive/"}
+lazy_static = "1"
 
 [lib]
 name = "v8_rs"

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
 
     static ref PROFILE: String = env::var("PROFILE").expect("PROFILE env var was not given");
 
-    static ref V8_DEFAULT_VERSION: &'static str = "11.4.183.23";
+    static ref V8_DEFAULT_VERSION: &'static str = "11.4.183.25";
     static ref V8_VERSION: String = env::var("V8_VERSION").map(|v| if v == "default" {V8_DEFAULT_VERSION.to_string()} else {v}).unwrap_or(V8_DEFAULT_VERSION.to_string());
     static ref V8_HEADERS_PATH: String = env::var("V8_HEADERS_PATH").unwrap_or("v8_c_api/libv8.include.zip".into());
     static ref V8_HEADERS_URL: String = env::var("V8_HEADERS_URL").unwrap_or(format!("http://redismodules.s3.amazonaws.com/redisgears/dependencies/libv8.{}.include.zip", *V8_VERSION));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ impl From<UserIndex> for RawIndex {
 
 #[cfg(test)]
 mod json_path_tests {
+    use std::sync::Mutex;
+
     use crate::v8::v8_array::V8LocalArray;
     use crate::v8::v8_object::V8LocalObject;
     use crate::v8::v8_utf8::V8LocalUtf8;
@@ -70,14 +72,15 @@ mod json_path_tests {
 
     use v8_derive::{new_native_function, NativeFunctionArgument};
 
-    static mut IS_INITIALIZED: bool = false;
+    lazy_static::lazy_static! {
+        static ref IS_INITIALIZED: Mutex<bool> = Mutex::new(false);
+    }
 
     fn initialize() {
-        unsafe {
-            if !IS_INITIALIZED {
-                v8_init(1, None).unwrap();
-                IS_INITIALIZED = true;
-            }
+        let mut is_initialized = IS_INITIALIZED.lock().unwrap();
+        if !*is_initialized {
+            v8_init(1, None).unwrap();
+            *is_initialized = true;
         }
     }
 

--- a/v8_c_api/src/v8include/v8-version.h
+++ b/v8_c_api/src/v8include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 11
 #define V8_MINOR_VERSION 4
 #define V8_BUILD_NUMBER 183
-#define V8_PATCH_LEVEL 23
+#define V8_PATCH_LEVEL 25
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)


### PR DESCRIPTION
In addition, remove the need to run the tests with a single thread by synchronise the V8 initialisation with a mutex.