### PR TITLE
Added on_dropped callback to V8LocalValue.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl From<UserIndex> for RawIndex {
 mod json_path_tests {
     use std::sync::Mutex;
 
-    use crate::v8::isolate_scope::GCType;
+    use crate::v8::isolate_scope::GarbageCollectionJobType;
     use crate::v8::v8_array::V8LocalArray;
     use crate::v8::v8_object::V8LocalObject;
     use crate::v8::v8_utf8::V8LocalUtf8;
@@ -1085,7 +1085,7 @@ mod json_path_tests {
         };
         let isolate_scope = isolate.enter();
         let _ctx_scope = ctx.enter(&isolate_scope);
-        isolate_scope.request_gc_for_testing(GCType::Full);
+        isolate_scope.request_gc_for_testing(GarbageCollectionJobType::Full);
         assert!(dropped_called);
     }
 }

--- a/src/v8/isolate_scope.rs
+++ b/src/v8/isolate_scope.rs
@@ -8,8 +8,8 @@ use crate::v8_c_raw::bindings::{
     v8_FreeHandlersScope, v8_IsolateEnter, v8_IsolateExit, v8_IsolateRaiseException, v8_NewArray,
     v8_NewArrayBuffer, v8_NewBool, v8_NewExternalData, v8_NewHandlersScope,
     v8_NewNativeFunctionTemplate, v8_NewNull, v8_NewObject, v8_NewObjectTemplate, v8_NewSet,
-    v8_NewString, v8_NewTryCatch, v8_NewUnlocker, v8_StringToValue, v8_ValueFromDouble,
-    v8_ValueFromLong, v8_handlers_scope, v8_isolate_scope, v8_local_value,
+    v8_NewString, v8_NewTryCatch, v8_NewUnlocker, v8_RequestGCFromTesting, v8_StringToValue,
+    v8_ValueFromDouble, v8_ValueFromLong, v8_handlers_scope, v8_isolate_scope, v8_local_value,
 };
 
 use crate::v8::isolate::V8Isolate;
@@ -29,7 +29,7 @@ use crate::v8::v8_string::V8LocalString;
 use crate::v8::v8_unlocker::V8Unlocker;
 use crate::v8::v8_value::V8LocalValue;
 
-use std::os::raw::{c_char, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 
 pub struct V8IsolateScope<'isolate> {
     pub(crate) isolate: &'isolate V8Isolate,
@@ -39,6 +39,11 @@ pub struct V8IsolateScope<'isolate> {
 
 extern "C" fn free_external_data<T>(arg1: *mut ::std::os::raw::c_void) {
     unsafe { Box::from_raw(arg1 as *mut T) };
+}
+
+pub enum GCType {
+    Full,
+    Minor,
 }
 
 impl<'isolate> V8IsolateScope<'isolate> {
@@ -53,6 +58,21 @@ impl<'isolate> V8IsolateScope<'isolate> {
             inner_handlers_scope,
             inner_isolate_scope,
         }
+    }
+
+    /// Request garbage collection. It is only valid to call this
+    /// function if --expose_gc was specified for the V8 flags.
+    ///
+    /// This should only be used for testing purposes and not to enforce a garbage
+    /// collection schedule. It has strong negative impact on the garbage
+    /// collection performance. Use [`V8Isolate::memory_pressure_notification`] instead to
+    /// influence the garbage collection schedule.
+    pub fn request_gc_for_testing(&self, gc_type: GCType) {
+        let full = match gc_type {
+            GCType::Full => true,
+            GCType::Minor => false,
+        };
+        unsafe { v8_RequestGCFromTesting(self.isolate.inner_isolate, full as c_int) };
     }
 
     /// Create a dummy isolate scope. This should be used only in case we know that

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1037,7 +1037,7 @@ void v8_PromiseThen(v8_local_promise* promise, v8_context_ref *ctx_ref, v8_local
 typedef void (*OnFreed)(void *);
 
 typedef struct ValueFreedCtx {
-	void(*on_freed)(void*);
+	OnFreed on_freed;
 	void *pd;
 	v8::Persistent<v8::Value> *weak;
 } ValueFreedCtx ;

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1034,6 +1034,8 @@ void v8_PromiseThen(v8_local_promise* promise, v8_context_ref *ctx_ref, v8_local
 	v8::MaybeLocal<v8::Promise> _may_local = promise->promise->Then(ctx_ref->context, resolve->func, reject->func);
 }
 
+typedef void (*OnFreed)(void *);
+
 typedef struct ValueFreedCtx {
 	void(*on_freed)(void*);
 	void *pd;
@@ -1048,7 +1050,7 @@ static void v8_ValueOnFreedCallback(const v8::WeakCallbackInfo<ValueFreedCtx> &d
 	V8_FREE(free_ctx);
 }
 
-void v8_ValueOnFreed(v8_local_value* value, v8_isolate *i, void(*on_freed)(void*), void *pd) {
+void v8_ValueOnFreed(v8_local_value* value, v8_isolate *i, OnFreed on_freed, void *pd) {
 	v8::Isolate *isolate = (v8::Isolate*)i;
 	v8::Persistent<v8::Value> *persist = new v8::Persistent<v8::Value>(isolate, value->val);
 	ValueFreedCtx *free_ctx = (ValueFreedCtx*)V8_ALLOC(sizeof(*free_ctx));

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -137,6 +137,9 @@ void v8_IsolateSetOOMErrorHandler(v8_isolate* i, void (*oom_hanlder)(const char*
 /* Set near OOM handler, the callback will be called when almost reaching OOM and allow to increase the max memory to avoid OOM error. */
 void v8_IsolateSetNearOOMHandler(v8_isolate* i, size_t (*near_oom_callback)(void* data, size_t current_heap_limit, size_t initial_heap_limit), void *pd, void(*free_pd)(void*));
 
+/* Request a GC run for testing */
+void v8_RequestGCFromTesting(v8_isolate* i, int full);
+
 /* Return the currently used heap size */
 size_t v8_IsolateUsedHeapSize(v8_isolate* i);
 
@@ -538,6 +541,9 @@ v8_local_value* v8_PromiseGetResult(v8_local_promise* promise);
 
 /* Set the promise fulfilled/rejected callbacks */
 void v8_PromiseThen(v8_local_promise* promise, v8_context_ref *ctx_ref, v8_local_native_function *resolve, v8_local_native_function *reject);
+
+/* Set a callback that will be called when the V8_Value will be GC */
+void v8_ValueOnFreed(v8_local_value* value, v8_isolate *i, void(*on_freed)(void*), void *pd);
 
 /* Convert the given promise object into a generic JS value. */
 v8_local_value* v8_PromiseToValue(v8_local_promise *promise);


### PR DESCRIPTION
Added an option to set an on_dropped callback on V8LocalValue. The given callback will be called when the GC will decide to collect the value. To test the new functionality, added an API to run GC for testing. We use this new API to force the GC to free the V8LocalValue and call our callback.