### PR TITLE
force native function to live for 'static lifetime.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,11 +452,12 @@ mod json_path_tests {
     }
 
     fn define_function_and_call<
-        F: for<'d, 'e> Fn(
-            &v8_native_function_template::V8LocalNativeFunctionArgs<'d, 'e>,
-            &'d isolate_scope::V8IsolateScope<'e>,
-            &v8_context_scope::V8ContextScope<'d, 'e>,
-        ) -> Option<v8_value::V8LocalValue<'d, 'e>>,
+        F: 'static
+            + for<'d, 'e> Fn(
+                &v8_native_function_template::V8LocalNativeFunctionArgs<'d, 'e>,
+                &'d isolate_scope::V8IsolateScope<'e>,
+                &v8_context_scope::V8ContextScope<'d, 'e>,
+            ) -> Option<v8_value::V8LocalValue<'d, 'e>>,
     >(
         code: &str,
         func_name: &str,

--- a/src/v8/isolate_scope.rs
+++ b/src/v8/isolate_scope.rs
@@ -277,11 +277,12 @@ impl<'isolate> V8IsolateScope<'isolate> {
     /// Create a new native function template.
     pub fn new_native_function_template<
         'isolate_scope,
-        T: for<'d, 'e> Fn(
-            &V8LocalNativeFunctionArgs<'d, 'e>,
-            &'d V8IsolateScope<'e>,
-            &V8ContextScope<'d, 'e>,
-        ) -> Option<V8LocalValue<'d, 'e>>,
+        T: 'static
+            + for<'d, 'e> Fn(
+                &V8LocalNativeFunctionArgs<'d, 'e>,
+                &'d V8IsolateScope<'e>,
+                &V8ContextScope<'d, 'e>,
+            ) -> Option<V8LocalValue<'d, 'e>>,
     >(
         &'isolate_scope self,
         func: T,

--- a/src/v8/v8_context_scope.rs
+++ b/src/v8/v8_context_scope.rs
@@ -227,11 +227,12 @@ impl<'isolate_scope, 'isolate> V8ContextScope<'isolate_scope, 'isolate> {
 
     #[must_use]
     pub fn new_native_function<
-        T: for<'d, 'c> Fn(
-            &V8LocalNativeFunctionArgs<'d, 'c>,
-            &'d V8IsolateScope<'c>,
-            &V8ContextScope<'d, 'c>,
-        ) -> Option<V8LocalValue<'d, 'c>>,
+        T: 'static
+            + for<'d, 'c> Fn(
+                &V8LocalNativeFunctionArgs<'d, 'c>,
+                &'d V8IsolateScope<'c>,
+                &V8ContextScope<'d, 'c>,
+            ) -> Option<V8LocalValue<'d, 'c>>,
     >(
         &self,
         func: T,

--- a/src/v8/v8_object.rs
+++ b/src/v8/v8_object.rs
@@ -86,11 +86,12 @@ impl<'isolate_scope, 'isolate> V8LocalObject<'isolate_scope, 'isolate> {
     }
 
     pub fn set_native_function<
-        T: for<'d, 'e> Fn(
-            &V8LocalNativeFunctionArgs<'d, 'e>,
-            &'d V8IsolateScope<'e>,
-            &V8ContextScope<'d, 'e>,
-        ) -> Option<V8LocalValue<'d, 'e>>,
+        T: 'static
+            + for<'d, 'e> Fn(
+                &V8LocalNativeFunctionArgs<'d, 'e>,
+                &'d V8IsolateScope<'e>,
+                &V8ContextScope<'d, 'e>,
+            ) -> Option<V8LocalValue<'d, 'e>>,
     >(
         &self,
         ctx_scope: &V8ContextScope,

--- a/src/v8/v8_object_template.rs
+++ b/src/v8/v8_object_template.rs
@@ -38,11 +38,12 @@ impl<'isolate_scope, 'isolate> V8LocalObjectTemplate<'isolate_scope, 'isolate> {
 
     /// Same as `set_native_function` but gets the key as &str and the native function as closure.
     pub fn add_native_function<
-        T: for<'d, 'e> Fn(
-            &V8LocalNativeFunctionArgs<'d, 'e>,
-            &'d V8IsolateScope<'e>,
-            &V8ContextScope<'d, 'e>,
-        ) -> Option<V8LocalValue<'d, 'e>>,
+        T: 'static
+            + for<'d, 'e> Fn(
+                &V8LocalNativeFunctionArgs<'d, 'e>,
+                &'d V8IsolateScope<'e>,
+                &V8ContextScope<'d, 'e>,
+            ) -> Option<V8LocalValue<'d, 'e>>,
     >(
         &mut self,
         name: &str,


### PR DESCRIPTION
There is not real limit for how long a native function can live. The V8 might even keep it for as long as it runs. This is why, when creating a native function, we should force it to live for 'static lifetime. Without this we can take ownership on V8LocalValue's that will be freed while the native function can still access them and this causes use after free issue.