### PR TITLE
Force external data to live for static lifetime

### DIFF
--- a/src/v8/isolate_scope.rs
+++ b/src/v8/isolate_scope.rs
@@ -37,7 +37,7 @@ pub struct V8IsolateScope<'isolate> {
     inner_isolate_scope: *mut v8_isolate_scope,
 }
 
-extern "C" fn free_external_data<T>(arg1: *mut ::std::os::raw::c_void) {
+extern "C" fn free_external_data<T: 'static>(arg1: *mut ::std::os::raw::c_void) {
     unsafe { Box::from_raw(arg1 as *mut T) };
 }
 
@@ -191,7 +191,7 @@ impl<'isolate> V8IsolateScope<'isolate> {
     }
 
     #[must_use]
-    pub fn new_external_data<'isolate_scope, T>(
+    pub fn new_external_data<'isolate_scope, T: 'static>(
         &'isolate_scope self,
         data: T,
     ) -> V8LocalExternalData<'isolate_scope, 'isolate> {


### PR DESCRIPTION
External data is also kept by the V8 engine for unlimited time and so we must force it live for the static lifetime. Notice that this does not mean that the value must live forever, it just means that it can not hold any none static references. For more information: https://practice.rs/lifetime/static.html#t-static