### PR TITLE
Seperate patform initialisation from V8 initialisation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ mod json_path_tests {
 
     use crate::v8::isolate_scope::GarbageCollectionJobType;
     use crate::v8::v8_array::V8LocalArray;
+    use crate::v8::v8_init_platform;
     use crate::v8::v8_object::V8LocalObject;
     use crate::v8::v8_utf8::V8LocalUtf8;
     use crate::v8::v8_value::V8LocalValue;
@@ -80,7 +81,8 @@ mod json_path_tests {
     fn initialize() {
         let mut is_initialized = IS_INITIALIZED.lock().unwrap();
         if !*is_initialized {
-            v8_init(1, Some("--expose-gc")).unwrap();
+            v8_init_platform(1, Some("--expose-gc")).unwrap();
+            v8_init().unwrap();
             *is_initialized = true;
         }
     }

--- a/src/v8/mod.rs
+++ b/src/v8/mod.rs
@@ -53,7 +53,7 @@ pub fn v8_init_platform(thread_pool_size: i32, flags: Option<&str>) -> Result<()
     };
     match res {
         1 => Ok(()),
-        _ => Err("The V8 Engine failed to initialise."),
+        _ => Err("The V8 default platform failed to initialise."),
     }
 }
 

--- a/src/v8/mod.rs
+++ b/src/v8/mod.rs
@@ -4,7 +4,7 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::v8_c_raw::bindings::{v8_Dispose, v8_Initialize, v8_Version};
+use crate::v8_c_raw::bindings::{v8_Dispose, v8_Initialize, v8_InitializePlatform, v8_Version};
 
 use std::ffi::{CStr, CString};
 use std::ptr;
@@ -42,16 +42,24 @@ pub trait OptionalTryFrom<T>: Sized {
     fn optional_try_from(value: T) -> Result<Option<Self>, Self::Error>;
 }
 
-/// Initialize the v8, must be called before any other v8 API.
-pub fn v8_init(thread_pool_size: i32, flags: Option<&str>) -> Result<(), &'static str> {
+/// Initialize default platform, must be called on the process main thread before calling any other v8 API (including [`v8_init`]).
+pub fn v8_init_platform(thread_pool_size: i32, flags: Option<&str>) -> Result<(), &'static str> {
     let flags_cstr = flags.map(|v| CString::new(v).unwrap());
     let res = unsafe {
-        v8_Initialize(
-            ptr::null_mut(),
+        v8_InitializePlatform(
             thread_pool_size,
             flags_cstr.as_ref().map_or(ptr::null_mut(), |v| v.as_ptr()),
         )
     };
+    match res {
+        1 => Ok(()),
+        _ => Err("The V8 Engine failed to initialise."),
+    }
+}
+
+/// Initialize the v8, must be called before any other v8 API.
+pub fn v8_init() -> Result<(), &'static str> {
+    let res = unsafe { v8_Initialize(ptr::null_mut()) };
     match res {
         1 => Ok(()),
         _ => Err("The V8 Engine failed to initialise."),
@@ -63,10 +71,8 @@ pub fn v8_init(thread_pool_size: i32, flags: Option<&str>) -> Result<(), &'stati
 pub fn v8_init_with_error_handlers(
     fatal_error_handler: Box<FatalErrorCallback>,
     oom_error_handler: Box<OutOfMemoryErrorCallback>,
-    thread_pool_size: i32,
-    flags: Option<&str>,
 ) -> Result<(), &'static str> {
-    v8_init(thread_pool_size, flags)?;
+    v8_init()?;
 
     unsafe {
         FATAL_ERROR_CALLBACK = Some(fatal_error_handler);

--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -270,8 +270,7 @@ v8_pd_list* v8_PDListCreate(v8::ArrayBuffer::Allocator *alloc) {
 	return native_data;
 }
 
-int v8_Initialize(v8_alloctor *alloc, int thread_pool_size, const char *flags) {
-//	v8::V8::SetFlagsFromString("--expose_gc");
+int v8_InitializePlatform(int thread_pool_size, const char *flags) {
 	if (flags) {
 		v8::V8::SetFlagsFromString(flags);
 	}
@@ -280,6 +279,10 @@ int v8_Initialize(v8_alloctor *alloc, int thread_pool_size, const char *flags) {
 		return 0;
 	}
 	platform = v8::platform::NewDefaultPlatform(thread_pool_size).release();
+	return 1;
+}
+
+int v8_Initialize(v8_alloctor *alloc) {
 	v8::V8::InitializePlatform(platform);
 	v8::V8::Initialize();
 

--- a/v8_c_api/src/v8_c_api.h
+++ b/v8_c_api/src/v8_c_api.h
@@ -113,7 +113,12 @@ typedef void (*v8_InterruptCallback)(v8_isolate *isolate, void* data);
  * Returns and int of value 1 on successfull initialisation, 0
  * otherwise.
  */
-int v8_Initialize(v8_alloctor *allocator, int thread_pool_size, const char *flags);
+int v8_Initialize(v8_alloctor *allocator);
+
+/** Initialize default platform, must be called on the process main thread before any v8 API (including `v8_Initialize`).
+ * Returns and int of value 1 on successfull initialisation, 0 otherwise.
+ */
+int v8_InitializePlatform(int thread_pool_size, const char *flags);
 
 const char* v8_Version();
 


### PR DESCRIPTION
The platform initialisation must happened on the process main thread, otherwise it causes crashes if later, trying to run JS code on the main thread.

Initialising platform is cheep and can happened on processes start. Initialise the V8 can be heavy and might require to happened only when V8 is in fact in use.

The PR Splits the platform initialisation from the V8 initialisation so the user can initialise them separately.