### PR TITLE
Don't produce a shared library artifact.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ ctor = "0.2.4"
 [lib]
 name = "v8_rs"
 path = "src/lib.rs"
-crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["debug-server"]

--- a/build.rs
+++ b/build.rs
@@ -107,9 +107,9 @@ fn main() {
                 "cargo:rustc-flags=-L{} -lv8 -lv8_monolith_{} -ldl -lc",
                 output_dir, *PROFILE
             );
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-Bstatic");
-            println!("cargo:rustc-cdylib-link-arg=-lstdc++");
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-Bdynamic");
+            println!(
+                "cargo:rustc-link-lib=stdc++",
+            );
         }
         "macos" => {
             println!(


### PR DESCRIPTION
The crate is not shipped as a shared library, and is not used as such.