### PR TITLE
Fix nightly ci by specify different flags for debug and release builds

### DIFF
--- a/v8_c_api/src/Makefile
+++ b/v8_c_api/src/Makefile
@@ -1,5 +1,12 @@
+GCC_FLAGS=-std=c++17 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX
+ifeq ($(DEBUG),1)
+	GCC_FLAGS+=-O0 -DV8_ENABLE_CHECKS
+else
+	GCC_FLAGS+=-O2
+endif
+
 build:
-	g++ -I./v8include -fPIC -c -o2 -g v8_c_api.cpp -o c8_c_api.o -std=c++17 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX
+	g++ -I./v8include -fPIC -c -g v8_c_api.cpp -o c8_c_api.o $(GCC_FLAGS)
 	ar r libv8.a c8_c_api.o
 	
 clean:


### PR DESCRIPTION
V8 added a new compilation flag, `V8_ENABLE_CHECKS`, which is enabled on debug build. When we compile this library for debug we must also enable this flag otherwise we will crash with a segfault as we see on this nightly build:
https://github.com/RedisGears/v8-rs/actions/runs/7517083331/job/20463102147

The PR compiles `v8_c_api` for debug or release base on the profile that was used on rust compilation (when running cargo).

(cherry picked from commit fff163c979b63209f3f52255bdd832f05580cd58)