### PR TITLE
Exit the isolate before unlcoking it.

### DIFF
--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -1902,7 +1902,7 @@ v8_unlocker* v8_NewUnlocker(v8_isolate *i) {
 
 void v8_FreeUnlocker(v8_unlocker* u) {
     v8::Isolate *isolate = u->isolate;
-    u->~v8_unlocker
+    u->~v8_unlocker();
     V8_FREE(u);
     isolate->Enter();
 }


### PR DESCRIPTION
According to the docs and follow the conversation on [this thread](https://groups.google.com/g/v8-dev/c/HssLPoP-pVk/m/lVBlVn9MAgAJ?utm_medium=email&utm_source=footer). The isolate must be exit before using the unlocker and re-entered right after the unlocker is destroyed.
This was caught by a recent debug check code that was added [here](https://chromium-review.googlesource.com/c/v8/v8/+/5173257).
Fixed the failure on nightly run: https://github.com/RedisGears/RedisGears/actions/runs/7539374024/job/20521749141#step:8:29264