### PR TITLE
Exit the isolate before unlcoking it. (#95)

### DIFF
--- a/v8_c_api/src/v8_c_api.cpp
+++ b/v8_c_api/src/v8_c_api.cpp
@@ -208,6 +208,12 @@ struct v8_embedded_data {
     }
 };
 
+struct v8_unlocker {
+	v8::Unlocker unlocker;
+	v8::Isolate *isolate;
+	v8_unlocker(v8::Isolate *i): unlocker(i), isolate(i) {}
+};
+
 typedef struct v8_native_function_pd v8_native_function_pd;
 typedef struct v8_pd_node v8_pd_node;
 typedef struct v8_pd_list v8_pd_list;
@@ -1534,13 +1540,16 @@ const char* v8_Utf8PtrLen(v8_utf8_value *val, size_t *len) {
 
 v8_unlocker* v8_NewUnlocker(v8_isolate *i) {
     v8::Isolate *isolate = (v8::Isolate*)i;
-    v8::Unlocker *unlocker = new v8::Unlocker(isolate);
-    return (v8_unlocker*)unlocker;
+    isolate->Exit();
+    v8_unlocker *unlocker = (struct v8_unlocker*)V8_ALLOC(sizeof(*unlocker));
+    return new (unlocker) v8_unlocker(isolate);
 }
 
 void v8_FreeUnlocker(v8_unlocker* u) {
-    v8::Unlocker *unlocker = (v8::Unlocker*)u;
-    delete unlocker;
+    v8::Isolate *isolate = u->isolate;
+    u->~v8_unlocker();
+    V8_FREE(u);
+    isolate->Enter();
 }
 
 }


### PR DESCRIPTION
According to the docs and follow the conversation on [this thread](https://groups.google.com/g/v8-dev/c/HssLPoP-pVk/m/lVBlVn9MAgAJ?utm_medium=email&utm_source=footer). The isolate must be exit before using the unlocker and re-entered right after the unlocker is destroyed. This was caught by a recent debug check code that was added [here](https://chromium-review.googlesource.com/c/v8/v8/+/5173257). Fixed the failure on nightly run: https://github.com/RedisGears/RedisGears/actions/runs/7539374024/job/20521749141#step:8:29264

(cherry picked from commit 472ecf622a6b6e96cd6c6012bff500e9cab518a5)